### PR TITLE
비밀번호 형식 지정 추가

### DIFF
--- a/albamate_sample/lib/screen/signup/signup_step2.dart
+++ b/albamate_sample/lib/screen/signup/signup_step2.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'signup_step3.dart';
+import 'dart:convert'; // ✅ 추가
+import 'package:http/http.dart' as http; // ✅ 추가
+
 
 class SignupStep2 extends StatefulWidget {
   final String email;
@@ -13,16 +16,32 @@ class SignupStep2 extends StatefulWidget {
 class _SignupStep2State extends State<SignupStep2> {
   final TextEditingController passwordController = TextEditingController();
   final TextEditingController confirmPasswordController =
-      TextEditingController();
+  TextEditingController();
   String statusMessage = '';
 
-  void _proceedToNextStep() {
+  Future<void> _proceedToNextStep() async {
     String password = passwordController.text.trim();
     String confirmPassword = confirmPasswordController.text.trim();
 
     if (password.isEmpty || confirmPassword.isEmpty) {
       setState(() {
         statusMessage = '비밀번호를 입력해주세요.';
+      });
+      return;
+    }
+    // ✅ Node.js 서버에 비밀번호 형식 검사 요청
+    final response = await http.post(
+      Uri.parse('https://backend-vgbf.onrender.com/auth/check-password'), // 🟡 여기에 Render 서버 주소 입력
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({'password': password}),
+    );
+
+    final result = jsonDecode(response.body);
+
+    // ✅ 서버 응답 기반으로 검사
+    if (!result['valid']) {
+      setState(() {
+        statusMessage = result['message'] ?? '비밀번호 형식이 올바르지 않습니다.';
       });
       return;
     }
@@ -65,7 +84,7 @@ class _SignupStep2State extends State<SignupStep2> {
             ),
             const SizedBox(height: 12),
             ElevatedButton(
-              onPressed: _proceedToNextStep,
+              onPressed: () => _proceedToNextStep(),
               child: const Text('다음 단계'),
             ),
             const SizedBox(height: 10),

--- a/albamate_sample/pubspec.yaml
+++ b/albamate_sample/pubspec.yaml
@@ -30,6 +30,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  http: ^1.3.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
변경 내용
비밀번호 형식 규칙을 추가하여, 최소 8자 이상의 길이와 영문 대소문자 및 숫자를 포함하도록 설정했습니다.

서버 배포 과정
로컬에서 변경 사항 테스트: 변경한 비밀번호 규칙을 로컬 서버에서 테스트합니다.

Render에 배포: GitHub 저장소와 연동된 Render에서 자동 배포가 진행됩니다.Render에서 제공하는 URL을 통해 웹 애플리케이션을 확인 가능합니다.

서버를 배포하였기에 따로 설치없이 안드로이드 스튜디오에서 실행하는 것 만으로 서버와 연결가능하도록 하였습니다
