### PR TITLE
캘린더 전체 수정

### DIFF
--- a/albamate_sample/lib/component/groupHome_navigation.dart
+++ b/albamate_sample/lib/component/groupHome_navigation.dart
@@ -33,12 +33,12 @@ class _GroupNavState extends State<GroupNav> {
       // 현재는 로그인 시 받은 role을 기준으로 분기
       // 향후 그룹 ownerId를 백엔드에서 가져와서 비교 후 이 부분만 교체
       widget.userRole.trim() == '사장님'
-          // widget.userRole.trim() == '알바생'
+      // widget.userRole.trim() == '알바생'
           ? BossScheduleHomePage(groupId: widget.groupId)
           : WorkerScheduleHomePage(groupId: widget.groupId),
       NoticePageNav(groupId: widget.groupId),
       GroupHomePage(groupId: widget.groupId),
-      GroupCalendarPage(groupId: widget.groupId),
+      GroupCalendarPage(userRole: widget.userRole, groupId: widget.groupId),
       GroupMyPage(),
     ];
 

--- a/albamate_sample/lib/screen/groupPage/groupCalendar.dart
+++ b/albamate_sample/lib/screen/groupPage/groupCalendar.dart
@@ -1,405 +1,401 @@
 import 'package:flutter/material.dart';
-import 'package:syncfusion_flutter_calendar/calendar.dart';
+import 'package:flutter_slidable/flutter_slidable.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+// import 'package:http/http.dart' as http;
+// import 'dart:convert';
+
+// "알바생"이면 수정 불가
 
 class GroupCalendarPage extends StatefulWidget {
+  final String userRole;
   final String groupId;
-  const GroupCalendarPage({super.key, required this.groupId});
+  const GroupCalendarPage({required this.userRole, required this.groupId, super.key});
 
   @override
   _GroupCalendarPageState createState() => _GroupCalendarPageState();
 }
 
 class _GroupCalendarPageState extends State<GroupCalendarPage> {
-  CalendarView _calendarView = CalendarView.month;
-  final List<Appointment> _appointments = []; // TODO: groupId 기준 일정 목록으로 대체 필요
-  final CalendarController _controller = CalendarController();
 
-  late int _displayYear;
-  late int _displayMonth;
+  DateTime _focusedDay = DateTime.now();
+  Map<DateTime, List<Appointment>> _events = {};
+  List<Appointment> _appointments = [];
 
   @override
   void initState() {
+    // 이미 생성자에서 전달받았고 widget.userRole/widget.groupId로 직접 접근
     super.initState();
-    final now = DateTime.now();
-    _controller.displayDate = now;
-    _displayYear = now.year;
-    _displayMonth = now.month;
+    // ⚠️ 아래 함수는 임시 주석처리 — 그룹 캘린더용 API가 필요함
+    // _fetchAppointments();
+  }
+
+  int _hexToColor(String hex) {
+    hex = hex.replaceFirst('#', '');
+    return int.parse('FF$hex', radix: 16);
   }
 
   @override
   Widget build(BuildContext context) {
-    final String yearMonth = "$_displayYear년 $_displayMonth월";
+    final int year = _focusedDay.year;
+    final int month = _focusedDay.month;
+    final lastDayOfMonth = DateTime(year, month + 1, 0);
+    final daysInMonth =
+    List.generate(lastDayOfMonth.day, (index) => DateTime(year, month, index + 1));
+
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text("그룹 캘린더"),
-        actions: [
-          PopupMenuButton<CalendarView>(
-            onSelected: (CalendarView value) {
-              setState(() {
-                _calendarView = value;
-              });
-            },
-            itemBuilder:
-                (context) => const [
-                  PopupMenuItem(value: CalendarView.day, child: Text("일간 보기")),
-                  PopupMenuItem(value: CalendarView.week, child: Text("주간 보기")),
-                  PopupMenuItem(
-                    value: CalendarView.month,
-                    child: Text("월간 보기"),
-                  ),
-                ],
+        title: Text("그룹 캘린더"),
+        actions: widget.userRole == "사장님"
+            ? [
+          TextButton.icon( style: TextButton.styleFrom(
+            backgroundColor: Color(0xFF006FFD),
           ),
-        ],
+            onPressed: () {
+              // TODO: 스케줄 연동 기능 연결
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(content: Text("스케줄 연동 기능은 준비 중입니다.")),
+              );
+            },
+            icon: Icon(Icons.link, color: Colors.white),
+            label: Text("연동", style: TextStyle(color: Colors.black)),
+
+          ),
+        ]
+            : null,
       ),
-      body: Column(
-        children: [
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 8),
-            child: Row(
+
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 IconButton(
-                  onPressed: _goToPreviousMonth,
-                  icon: const Icon(Icons.chevron_left),
+                  icon: Icon(Icons.chevron_left),
+                  onPressed: () => setState(
+                          () => _focusedDay = DateTime(year, month - 1)),
                 ),
-                Expanded(
-                  child: GestureDetector(
-                    onTap: _showMonthYearPicker,
-                    child: Center(
-                      child: Text(
-                        yearMonth,
-                        style: const TextStyle(
-                          fontSize: 18,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
+                Text("${year}년 ${month}월",
+                    style:
+                    TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
                 IconButton(
-                  onPressed: _goToNextMonth,
-                  icon: const Icon(Icons.chevron_right),
+                  icon: Icon(Icons.chevron_right),
+                  onPressed: () => setState(
+                          () => _focusedDay = DateTime(year, month + 1)),
                 ),
               ],
             ),
-          ),
-          Expanded(
-            child: SfCalendar(
-              controller: _controller,
-              view: _calendarView,
-              dataSource: MeetingDataSource(_appointments),
-              firstDayOfWeek: 1,
-              todayHighlightColor: Colors.red,
-              cellBorderColor: Colors.transparent,
-              headerHeight: 0,
-              showDatePickerButton: false,
-              monthViewSettings: const MonthViewSettings(
-                showTrailingAndLeadingDates: false,
-                appointmentDisplayMode: MonthAppointmentDisplayMode.appointment,
+            Padding(
+              padding: const EdgeInsets.only(bottom: 4.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: const [
+                  Text("일", style: TextStyle(fontWeight: FontWeight.bold)),
+                  Text("월", style: TextStyle(fontWeight: FontWeight.bold)),
+                  Text("화", style: TextStyle(fontWeight: FontWeight.bold)),
+                  Text("수", style: TextStyle(fontWeight: FontWeight.bold)),
+                  Text("목", style: TextStyle(fontWeight: FontWeight.bold)),
+                  Text("금", style: TextStyle(fontWeight: FontWeight.bold)),
+                  Text("토", style: TextStyle(fontWeight: FontWeight.bold)),
+                ],
               ),
-              monthCellBuilder: (context, details) {
-                final isToday =
-                    details.date.year == DateTime.now().year &&
-                    details.date.month == DateTime.now().month &&
-                    details.date.day == DateTime.now().day;
-                return Container(
-                  alignment: Alignment.topCenter,
-                  padding: const EdgeInsets.only(top: 4),
-                  child: Stack(
-                    alignment: Alignment.center,
-                    children: [
-                      if (isToday)
-                        Container(
-                          width: 20,
-                          height: 20,
-                          decoration: const BoxDecoration(
-                            color: Colors.red,
-                            shape: BoxShape.circle,
-                          ),
-                        ),
-                      Text(
-                        '${details.date.day}',
-                        style: TextStyle(
-                          color: isToday ? Colors.white : Colors.black,
-                          fontSize: 12,
-                        ),
-                      ),
-                    ],
-                  ),
-                );
-              },
-              onTap: (details) {
-                if (details.date != null) {
-                  _showDayDetailSheet(details.date!);
-                }
-              },
             ),
-          ),
-        ],
+            Table(
+              border: TableBorder.symmetric(
+                inside: BorderSide(color: Colors.grey.shade300),
+              ),
+              columnWidths: const {
+                0: FlexColumnWidth(), 1: FlexColumnWidth(), 2: FlexColumnWidth(),
+                3: FlexColumnWidth(), 4: FlexColumnWidth(), 5: FlexColumnWidth(),
+                6: FlexColumnWidth(),
+              },
+              children: _buildCalendarRows(daysInMonth),
+            ),
+          ],
+        ),
       ),
     );
   }
 
-  void _goToPreviousMonth() {
-    final current = _controller.displayDate ?? DateTime.now();
-    final prev = DateTime(current.year, current.month - 1);
-    setState(() {
-      _controller.displayDate = prev;
-      _displayYear = prev.year;
-      _displayMonth = prev.month;
-    });
-  }
+  List<TableRow> _buildCalendarRows(List<DateTime> daysInMonth) {
+    List<TableRow> rows = [];
+    List<Widget> cells = [];
+    int startWeekday = daysInMonth.first.weekday % 7;
 
-  void _goToNextMonth() {
-    final current = _controller.displayDate ?? DateTime.now();
-    final next = DateTime(current.year, current.month + 1);
-    setState(() {
-      _controller.displayDate = next;
-      _displayYear = next.year;
-      _displayMonth = next.month;
-    });
-  }
+    for (int i = 0; i < startWeekday; i++) {
+      cells.add(Container(height: 80));
+    }
 
-  void _showMonthYearPicker() async {
-    int tempYear = _displayYear;
-    int tempMonth = _displayMonth;
+    for (final date in daysInMonth) {
+      final today = DateTime.now();
+      final isToday = date.year == today.year && date.month == today.month && date.day == today.day;
+      final events = _events[date] ?? [];
 
-    await showModalBottomSheet(
-      context: context,
-      builder: (_) {
-        return StatefulBuilder(
-          builder: (context, setModalState) {
-            return Container(
-              padding: const EdgeInsets.all(16),
-              height: 220,
-              child: Column(
-                children: [
-                  const Text("년도 / 월 선택", style: TextStyle(fontSize: 16)),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      DropdownButton<int>(
-                        value: tempYear,
-                        items:
-                            List.generate(10, (index) => 2020 + index)
-                                .map(
-                                  (year) => DropdownMenuItem(
-                                    value: year,
-                                    child: Text("$year년"),
-                                  ),
-                                )
-                                .toList(),
-                        onChanged: (value) {
-                          if (value != null) {
-                            setModalState(() => tempYear = value);
-                            setState(() => _displayYear = value);
-                          }
-                        },
-                      ),
-                      const SizedBox(width: 16),
-                      DropdownButton<int>(
-                        value: tempMonth,
-                        items:
-                            List.generate(12, (index) => index + 1)
-                                .map(
-                                  (month) => DropdownMenuItem(
-                                    value: month,
-                                    child: Text("$month월"),
-                                  ),
-                                )
-                                .toList(),
-                        onChanged: (value) {
-                          if (value != null) {
-                            setModalState(() => tempMonth = value);
-                            setState(() => _displayMonth = value);
-                          }
-                        },
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 16),
-                  ElevatedButton(
-                    onPressed: () {
-                      setState(() {
-                        _controller.displayDate = DateTime(tempYear, tempMonth);
-                      });
-                      Navigator.pop(context);
-                    },
-                    child: const Text("이동하기"),
-                  ),
-                ],
+      cells.add(GestureDetector(
+        onTap: () => _showDayDetailSheet(date),
+        child: Container(
+          padding: EdgeInsets.all(4),
+          constraints: BoxConstraints(minHeight: 80 + 20.0 * events.length),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                padding: EdgeInsets.all(4),
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: isToday ? Colors.blue : null,
+                ),
+                alignment: Alignment.center,
+                child: Text('${date.day}',
+                    style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        color: isToday ? Colors.white : Colors.black)),
               ),
-            );
-          },
-        );
-      },
-    );
+              ...events.take(5).map((e) => Container(
+                height: 20,
+                margin: EdgeInsets.only(top: 2),
+                padding: EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+                decoration: BoxDecoration(
+                  color: e.color,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Text(
+                  e.subject,
+                  style: TextStyle(fontSize: 10),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              )),
+              if (events.length > 5)
+                Text('+${events.length - 5}',
+                    style: TextStyle(fontSize: 10, color: Colors.grey))
+            ],
+          ),
+        ),
+      ));
+
+      if (cells.length == 7) {
+        rows.add(TableRow(children: List.from(cells)));
+        cells.clear();
+      }
+    }
+
+    if (cells.isNotEmpty) {
+      while (cells.length < 7) {
+        cells.add(Container(height: 80));
+      }
+      rows.add(TableRow(children: List.from(cells)));
+    }
+
+    return rows;
   }
 
   void _showDayDetailSheet(DateTime date) {
-    final dayAppointments =
-        _appointments
-            .where(
-              (a) =>
-                  a.startTime.year == date.year &&
-                  a.startTime.month == date.month &&
-                  a.startTime.day == date.day,
-            )
-            .toList();
+    final dayAppointments = _events[date] ?? [];
 
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
-      builder:
-          (context) => DraggableScrollableSheet(
-            expand: false,
-            builder:
-                (context, scrollController) => Scaffold(
-                  appBar: AppBar(
-                    title: Text("${date.month}월 ${date.day}일 일정"),
-                    actions: [
-                      IconButton(
-                        icon: const Icon(Icons.add),
-                        onPressed: () {
-                          Navigator.pop(context);
-                          _showAddDialog(date);
-                        },
-                      ),
-                    ],
-                  ),
-                  body: ListView.builder(
-                    controller: scrollController,
-                    itemCount: dayAppointments.length,
-                    itemBuilder: (context, index) {
-                      final appt = dayAppointments[index];
-                      return ListTile(
-                        title: Text(appt.subject),
-                        trailing: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            IconButton(
-                              icon: const Icon(Icons.edit, color: Colors.blue),
-                              onPressed: () {
-                                Navigator.pop(context);
-                                _showEditDialog(appt);
-                              },
-                            ),
-                            IconButton(
-                              icon: const Icon(Icons.delete, color: Colors.red),
-                              onPressed: () {
-                                setState(() => _appointments.remove(appt));
-                                Navigator.pop(context);
-                                _showDayDetailSheet(date);
-                              },
-                            ),
-                          ],
-                        ),
-                      );
-                    },
+      builder: (context) => DraggableScrollableSheet(
+        expand: false,
+        builder: (context, scrollController) => Scaffold(
+          appBar: AppBar(
+            title: Text("${date.month}월 ${date.day}일 일정"),
+            actions: [
+              if (widget.userRole == "사장님")
+                IconButton(
+                  icon: Icon(Icons.add),
+                  onPressed: () {
+                    Navigator.pop(context);
+                    _showAddDialog(date);
+                  },
+                ),
+            ],
+          ),
+          body: ListView.builder(
+            controller: scrollController,
+            itemCount: dayAppointments.length,
+            itemBuilder: (context, index) {
+              final appt = dayAppointments[index];
+              return Slidable(
+                key: ValueKey(appt.notes ?? '${appt.subject}-$index'),
+                endActionPane: widget.userRole == "사장님"
+                    ? ActionPane(
+                  motion: const ScrollMotion(),
+                  extentRatio: 0.4,
+                  children: [
+                    SlidableAction(
+                      onPressed: (_) {
+                        Navigator.pop(context);
+                        _showEditDialog(appt);
+                      },
+                      backgroundColor: Colors.blue.shade50,
+                      foregroundColor: Colors.blue,
+                      icon: Icons.edit,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    SlidableAction(
+                      onPressed: (_) async {
+                        // ⚠️ 여기에 그룹 일정 삭제용 DELETE API 연동 필요
+                      },
+                      backgroundColor: Colors.red.shade50,
+                      foregroundColor: Colors.red,
+                      icon: Icons.delete,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ],
+                )
+                    : null,
+                child: ListTile(
+                  title: Text(appt.subject),
+                  leading: Container(
+                    width: 12,
+                    height: 12,
+                    decoration: BoxDecoration(
+                      color: appt.color,
+                      shape: BoxShape.rectangle,
+                      borderRadius: BorderRadius.circular(2),
+                    ),
                   ),
                 ),
+              );
+            },
           ),
+        ),
+      ),
     );
   }
 
-  void _showAddDialog(DateTime selectedDate) {
+  // _showAddDialog와 _showEditDialog는 이미 포함되어 있음
+
+  void _showAddDialog(DateTime date) {
     String title = "";
-    TimeOfDay start = TimeOfDay(hour: selectedDate.hour, minute: 0);
-    TimeOfDay end = TimeOfDay(hour: (selectedDate.hour + 1) % 24, minute: 0);
+    Color selectedColor = Color(0xFFFEE1E8);
+    TimeOfDay start = TimeOfDay(hour: 9, minute: 0);
+    TimeOfDay end = TimeOfDay(hour: 10, minute: 0);
 
     showModalBottomSheet(
       context: context,
-      builder: (_) {
-        return Padding(
-          padding: const EdgeInsets.all(16),
+      builder: (_) => StatefulBuilder(
+        builder: (context, setModalState) => Padding(
+          padding: EdgeInsets.all(16),
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              const Text("일정 추가", style: TextStyle(fontSize: 18)),
+              Text("일정 추가", style: TextStyle(fontSize: 18)),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  '#FEE1E8', '#F6EAC2', '#D3E5EF', '#D4F0C0',
+                  '#FFF5BA', '#F8D1C1', '#E2DAF9', '#B2EBF2'
+                ].map((hex) {
+                  final color = Color(int.parse('FF${hex.substring(1)}', radix: 16));
+                  return GestureDetector(
+                    onTap: () => setModalState(() => selectedColor = color),
+                    child: Container(
+                      width: 30,
+                      height: 30,
+                      decoration: BoxDecoration(
+                        color: color,
+                        shape: BoxShape.circle,
+                        border: Border.all(
+                          color: selectedColor == color ? Colors.black : Colors.transparent,
+                          width: 2,
+                        ),
+                      ),
+                    ),
+                  );
+                }).toList(),
+              ),
               TextField(
-                decoration: const InputDecoration(labelText: '제목'),
+                decoration: InputDecoration(labelText: '제목'),
                 onChanged: (value) => title = value,
               ),
-              const SizedBox(height: 10),
               ElevatedButton(
-                child: const Text("추가"),
-                onPressed: () {
-                  final newAppointment = Appointment(
-                    startTime: DateTime(
-                      selectedDate.year,
-                      selectedDate.month,
-                      selectedDate.day,
-                      start.hour,
-                      start.minute,
-                    ),
-                    endTime: DateTime(
-                      selectedDate.year,
-                      selectedDate.month,
-                      selectedDate.day,
-                      end.hour,
-                      end.minute,
-                    ),
-                    subject: title,
-                    color: Colors.orange,
-                  );
-                  setState(() => _appointments.add(newAppointment));
-                  Navigator.pop(context);
+                child: Text("추가"),
+                onPressed: () async {
+                  // ⚠️ 여기에 그룹 일정 저장용 POST API 연동 필요
                 },
               ),
             ],
           ),
-        );
-      },
+        ),
+      ),
     );
   }
 
-  void _showEditDialog(Appointment oldAppointment) {
-    String title = oldAppointment.subject;
-    TimeOfDay start = TimeOfDay.fromDateTime(oldAppointment.startTime);
-    TimeOfDay end = TimeOfDay.fromDateTime(oldAppointment.endTime);
+  void _showEditDialog(Appointment appt) {
+    String title = appt.subject;
+    Color selectedColor = appt.color;
+    TimeOfDay start = TimeOfDay.fromDateTime(appt.startTime);
+    TimeOfDay end = TimeOfDay.fromDateTime(appt.endTime);
 
     showModalBottomSheet(
       context: context,
-      builder: (_) {
-        return Padding(
-          padding: const EdgeInsets.all(16),
+      builder: (_) => StatefulBuilder(
+        builder: (context, setModalState) => Padding(
+          padding: EdgeInsets.all(16),
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              const Text("일정 수정", style: TextStyle(fontSize: 18)),
+              Text("일정 수정", style: TextStyle(fontSize: 18)),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  '#FEE1E8', '#F6EAC2', '#D3E5EF', '#D4F0C0',
+                  '#FFF5BA', '#F8D1C1', '#E2DAF9', '#B2EBF2'
+                ].map((hex) {
+                  final color = Color(int.parse('FF${hex.substring(1)}', radix: 16));
+                  return GestureDetector(
+                    onTap: () => setModalState(() => selectedColor = color),
+                    child: Container(
+                      width: 30,
+                      height: 30,
+                      decoration: BoxDecoration(
+                        color: color,
+                        shape: BoxShape.circle,
+                        border: Border.all(
+                          color: selectedColor == color ? Colors.black : Colors.transparent,
+                          width: 2,
+                        ),
+                      ),
+                    ),
+                  );
+                }).toList(),
+              ),
               TextField(
                 controller: TextEditingController(text: title),
-                decoration: const InputDecoration(labelText: '제목'),
+                decoration: InputDecoration(labelText: '제목'),
                 onChanged: (value) => title = value,
               ),
-              const SizedBox(height: 10),
               ElevatedButton(
-                child: const Text("수정"),
-                onPressed: () {
-                  final index = _appointments.indexOf(oldAppointment);
-                  if (index == -1) return;
-
-                  final updated = Appointment(
-                    startTime: oldAppointment.startTime,
-                    endTime: oldAppointment.endTime,
-                    subject: title,
-                    color: oldAppointment.color,
-                  );
-
-                  setState(() => _appointments[index] = updated);
-                  Navigator.pop(context);
+                child: Text("수정"),
+                onPressed: () async {
+                  // ⚠️ 여기에 그룹 일정 수정용 PATCH API 연동 필요
                 },
               ),
             ],
           ),
-        );
-      },
+        ),
+      ),
     );
   }
 }
 
-class MeetingDataSource extends CalendarDataSource {
-  MeetingDataSource(List<Appointment> source) {
-    appointments = source;
-  }
+class Appointment {
+  final DateTime startTime;
+  final DateTime endTime;
+  final String subject;
+  final Color color;
+  final String? notes;
+
+  Appointment({
+    required this.startTime,
+    required this.endTime,
+    required this.subject,
+    required this.color,
+    this.notes,
+  });
 }

--- a/albamate_sample/lib/screen/homePage/boss/boss_homeCalendar.dart
+++ b/albamate_sample/lib/screen/homePage/boss/boss_homeCalendar.dart
@@ -127,6 +127,21 @@ class _BossHomecalendarState extends State<BossHomecalendar> {
                 ],
               ),
             ),
+            Padding(
+              padding: const EdgeInsets.only(bottom: 4.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: const [
+                  Text("일", style: TextStyle(fontWeight: FontWeight.bold)),
+                  Text("월", style: TextStyle(fontWeight: FontWeight.bold)),
+                  Text("화", style: TextStyle(fontWeight: FontWeight.bold)),
+                  Text("수", style: TextStyle(fontWeight: FontWeight.bold)),
+                  Text("목", style: TextStyle(fontWeight: FontWeight.bold)),
+                  Text("금", style: TextStyle(fontWeight: FontWeight.bold)),
+                  Text("토", style: TextStyle(fontWeight: FontWeight.bold)),
+                ],
+              ),
+            ),
             //커스텀 달력 Table UI
             Table(
               border: TableBorder(


### PR DESCRIPTION
1. 직원 개인 캘린더 (사장 개인캘린더와 같은 UI로 수정)
2. 직원 개인캘린더, 사장 개인캘린더에 모두 요일 (일 , 월, 화,수,목,금,토) 추가
3. 그룹 캘린더 UI 수정
- 그룹캘린더 API 추가해야함 (수정필요)
- 사장님 : 일정 추가, 삭제, 수정 버튼 있음 / 알바생: 일정 추가 버튼 아예없음
- 사장님 : 스케줄 연동 버튼있음 / 알바생 : 스케줄 연동 버튼 없음 (연동 기능은 아직 구현 안함, 버튼만 생성해놓음)
- 화면에 사장님이랑 알바생  쓸 수 있는 기능 차별화 해야해서 userRole 사용