### PR TITLE
스케줄 기능 벡엔드 구현

### DIFF
--- a/albamate_sample/lib/component/groupHome_navigation.dart
+++ b/albamate_sample/lib/component/groupHome_navigation.dart
@@ -33,12 +33,12 @@ class _GroupNavState extends State<GroupNav> {
       // 현재는 로그인 시 받은 role을 기준으로 분기
       // 향후 그룹 ownerId를 백엔드에서 가져와서 비교 후 이 부분만 교체
       widget.userRole.trim() == '사장님'
-      // widget.userRole.trim() == '알바생'
+          // widget.userRole.trim() == '알바생'
           ? BossScheduleHomePage(groupId: widget.groupId)
           : WorkerScheduleHomePage(groupId: widget.groupId),
       NoticePageNav(groupId: widget.groupId),
       GroupHomePage(groupId: widget.groupId),
-      GroupCalendarPage(userRole: widget.userRole, groupId: widget.groupId),
+      GroupCalendarPage(groupId: widget.groupId),
       GroupMyPage(),
     ];
 

--- a/albamate_sample/lib/component/groupHome_navigation.dart
+++ b/albamate_sample/lib/component/groupHome_navigation.dart
@@ -33,12 +33,12 @@ class _GroupNavState extends State<GroupNav> {
       // 현재는 로그인 시 받은 role을 기준으로 분기
       // 향후 그룹 ownerId를 백엔드에서 가져와서 비교 후 이 부분만 교체
       widget.userRole.trim() == '사장님'
-          // widget.userRole.trim() == '알바생'
+      // widget.userRole.trim() == '알바생'
           ? BossScheduleHomePage(groupId: widget.groupId)
           : WorkerScheduleHomePage(groupId: widget.groupId),
       NoticePageNav(groupId: widget.groupId),
       GroupHomePage(groupId: widget.groupId),
-      GroupCalendarPage(groupId: widget.groupId),
+      GroupCalendarPage(userRole: widget.userRole, groupId: widget.groupId),
       GroupMyPage(),
     ];
 

--- a/albamate_sample/lib/component/scheduleNav.dart
+++ b/albamate_sample/lib/component/scheduleNav.dart
@@ -34,6 +34,7 @@ class _ScheduleRequestTabState extends State<ScheduleRequestTab> {
             month: post['month'],
             // TODO: ⚠️ 현재 userRole 임시 사용 중 (백엔드 ownerId 연동 시 제거 예정)
             userRole: '',
+            groupId: widget.groupId,
           ),
         ),
         const SizedBox(height: 80),

--- a/albamate_sample/lib/main.dart
+++ b/albamate_sample/lib/main.dart
@@ -1,15 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_dynamic_links/firebase_dynamic_links.dart';
-import 'package:intl/date_symbol_data_local.dart'; // 추가
+import 'package:intl/date_symbol_data_local.dart'; // ✅ 추가
 import 'firebase_options.dart';
 import 'screen/onboarding.dart';
 import 'screen/invite/invite_handler.dart'; // ❗️이 파일을 따로 만들어야 함
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  // 로케일 데이터 초기화 (ko_KR용 DateFormat 사용 시 필요)
+  await Supabase.initialize(
+    url: 'https://unkliehgimaceqjjrmmx.supabase.co',
+    anonKey: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InVua2xpZWhnaW1hY2VxampybW14Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDYzNTE0MDAsImV4cCI6MjA2MTkyNzQwMH0.P0kUwkZbTXc8PjBMo15FKb2vKVj6b83vFchO1icV2fE',
+  );
+
+  // ✅ 로케일 데이터 초기화 (ko_KR용 DateFormat 사용 시 필요)
   await initializeDateFormatting('ko_KR', null);
 
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);

--- a/albamate_sample/lib/screen/groupPage/schedule/boss_scheduleView.dart
+++ b/albamate_sample/lib/screen/groupPage/schedule/boss_scheduleView.dart
@@ -1,13 +1,19 @@
 import 'package:albamate_sample/screen/groupPage/schedule/schedule_build.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:http/http.dart' as http;
+import 'package:firebase_auth/firebase_auth.dart';
+import 'dart:convert';
 
 class BossScheduleViewPage extends StatefulWidget {
+  final String groupId;
   final String scheduleId;
   final int year;
   final int month;
 
   const BossScheduleViewPage({
+    required this.groupId,
     super.key,
     required this.scheduleId,
     required this.year,
@@ -19,22 +25,78 @@ class BossScheduleViewPage extends StatefulWidget {
 }
 
 class _BossScheduleViewPageState extends State<BossScheduleViewPage> {
-  final List<String> mockUsers = ['Alice', 'Bob', 'Charlie'];
-  final Map<String, Set<int>> mockUnavailable = {
-    'Alice': {3, 7, 15},
-    'Bob': {5, 7, 23},
-    'Charlie': {10, 15, 20},
-  };
-
   late DateTime fixedMonth;
+  bool isLoading = true;
+
+  Map<String, List<String>> unavailableMap = {};
+  Map<String, String> userNameMap = {};
 
   @override
   void initState() {
     super.initState();
     fixedMonth = DateTime(widget.year, widget.month);
+    fetchUnavailableData();
   }
 
-  List<Widget> buildCalendarDays(String user) {
+  Future<void> fetchUnavailableData() async {
+    try {
+      final user = FirebaseAuth.instance.currentUser;
+      final idToken = await user?.getIdToken();
+
+      final response = await http.get(
+        Uri.parse('https://backend-schedule-vs8b.onrender.com/api/schedules/${widget.scheduleId}/unavailable/all'),
+        headers: {'Authorization': 'Bearer $idToken'},
+      );
+
+      final decoded = jsonDecode(response.body);
+      final dynamic rawData = decoded['data'];
+
+      if (rawData is Map<String, dynamic>) {
+        Map<String, List<String>> parsedData = {};
+        rawData.forEach((uid, list) {
+          parsedData[uid] = List<String>.from((list as List).map((e) => e.toString()));
+        });
+
+        final uids = parsedData.keys.toList();
+
+        if (uids.isEmpty) {
+          setState(() {
+            unavailableMap = {};
+            userNameMap = {};
+            isLoading = false;
+          });
+          return;
+        }
+
+        final snapshot = await FirebaseFirestore.instance
+            .collection('users')
+            .where(FieldPath.documentId, whereIn: uids)
+            .get();
+
+        Map<String, String> nameMap = {};
+        for (var doc in snapshot.docs) {
+          nameMap[doc.id] = doc.data()['name'] ?? '알 수 없음';
+        }
+
+        setState(() {
+          unavailableMap = parsedData;
+          userNameMap = nameMap;
+          isLoading = false;
+        });
+      } else {
+        throw Exception('예상치 못한 데이터 형식');
+      }
+    } catch (e) {
+      print('❌ 에러 발생: $e');
+      setState(() {
+        unavailableMap = {};
+        userNameMap = {};
+        isLoading = false;
+      });
+    }
+  }
+
+  List<Widget> buildCalendarDays(List<String> unavailableDates) {
     final firstDayOfMonth = DateTime(fixedMonth.year, fixedMonth.month, 1);
     final lastDayOfMonth = DateTime(fixedMonth.year, fixedMonth.month + 1, 0);
     final firstWeekday = firstDayOfMonth.weekday % 7;
@@ -44,13 +106,12 @@ class _BossScheduleViewPageState extends State<BossScheduleViewPage> {
     List<Widget> currentRow = [];
 
     for (int i = 0; i < firstWeekday; i++) {
-      currentRow.add(
-        Container(width: 40, height: 40, margin: const EdgeInsets.all(2)),
-      );
+      currentRow.add(Container(width: 40, height: 40, margin: const EdgeInsets.all(2)));
     }
 
     for (int day = 1; day <= totalDays; day++) {
-      final isUnavailable = mockUnavailable[user]?.contains(day) ?? false;
+      final dateStr = DateFormat('yyyy-MM-dd').format(DateTime(fixedMonth.year, fixedMonth.month, day));
+      final isUnavailable = unavailableDates.contains(dateStr);
 
       currentRow.add(
         Container(
@@ -68,28 +129,16 @@ class _BossScheduleViewPageState extends State<BossScheduleViewPage> {
       );
 
       if (currentRow.length == 7) {
-        rows.add(
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            children: currentRow,
-          ),
-        );
+        rows.add(Row(mainAxisAlignment: MainAxisAlignment.spaceEvenly, children: currentRow));
         currentRow = [];
       }
     }
 
     if (currentRow.isNotEmpty) {
       while (currentRow.length < 7) {
-        currentRow.add(
-          Container(width: 40, height: 40, margin: const EdgeInsets.all(2)),
-        );
+        currentRow.add(Container(width: 40, height: 40, margin: const EdgeInsets.all(2)));
       }
-      rows.add(
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: currentRow,
-        ),
-      );
+      rows.add(Row(mainAxisAlignment: MainAxisAlignment.spaceEvenly, children: currentRow));
     }
 
     return rows;
@@ -98,79 +147,84 @@ class _BossScheduleViewPageState extends State<BossScheduleViewPage> {
   @override
   Widget build(BuildContext context) {
     final monthText = DateFormat('yyyy. MM').format(fixedMonth);
+    final userUids = unavailableMap.keys.toList();
+
+    if (isLoading) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
 
     return DefaultTabController(
-      length: mockUsers.length,
+      length: userUids.length,
       child: Scaffold(
         appBar: AppBar(
           title: const Text('알바생 스케줄 보기'),
-          bottom: TabBar(
-            isScrollable: true,
-            tabs: mockUsers.map((user) => Tab(text: user)).toList(),
-          ),
+          bottom: userUids.isEmpty
+              ? null
+              : TabBar(
+                  isScrollable: true,
+                  tabs: userUids.map((uid) {
+                    final name = userNameMap[uid] ?? uid;
+                    return Tab(text: name);
+                  }).toList(),
+                ),
         ),
-        body: Column(
-          children: [
-            Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: Center(
-                child: Text(
-                  monthText,
-                  style: const TextStyle(
-                    fontSize: 18,
-                    fontWeight: FontWeight.bold,
+        body: userUids.isEmpty
+            ? const Center(child: Text('아직 제출한 알바생이 없습니다.'))
+            : Column(
+                children: [
+                  const SizedBox(height: 16),
+                  Text(monthText, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                  const SizedBox(height: 8),
+                  const Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    children: [
+                      SizedBox(width: 40, child: Center(child: Text('일'))),
+                      SizedBox(width: 40, child: Center(child: Text('월'))),
+                      SizedBox(width: 40, child: Center(child: Text('화'))),
+                      SizedBox(width: 40, child: Center(child: Text('수'))),
+                      SizedBox(width: 40, child: Center(child: Text('목'))),
+                      SizedBox(width: 40, child: Center(child: Text('금'))),
+                      SizedBox(width: 40, child: Center(child: Text('토'))),
+                    ],
                   ),
-                ),
-              ),
-            ),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: const [
-                SizedBox(width: 40, child: Center(child: Text('일'))),
-                SizedBox(width: 40, child: Center(child: Text('월'))),
-                SizedBox(width: 40, child: Center(child: Text('화'))),
-                SizedBox(width: 40, child: Center(child: Text('수'))),
-                SizedBox(width: 40, child: Center(child: Text('목'))),
-                SizedBox(width: 40, child: Center(child: Text('금'))),
-                SizedBox(width: 40, child: Center(child: Text('토'))),
-              ],
-            ),
-            const SizedBox(height: 8),
-            Expanded(
-              child: TabBarView(
-                children:
-                    mockUsers.map((user) {
-                      return Padding(
-                        padding: const EdgeInsets.all(16.0),
-                        child: SingleChildScrollView(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: buildCalendarDays(user),
+                  const SizedBox(height: 8),
+                  Expanded(
+                    child: TabBarView(
+                      children: userUids.map((uid) {
+                        final dates = unavailableMap[uid] ?? [];
+                        return Padding(
+                          padding: const EdgeInsets.all(16.0),
+                          child: SingleChildScrollView(
+                            child: Column(children: buildCalendarDays(dates)),
                           ),
-                        ),
-                      );
-                    }).toList(),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: SizedBox(
-                width: double.infinity,
-                child: ElevatedButton(
-                  onPressed: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) => const ScheduleBuildPage(),
+                        );
+                      }).toList(),
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: SizedBox(
+                      width: double.infinity,
+                      child: ElevatedButton(
+                        onPressed: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => ScheduleBuildPage(
+                                unavailableMap: unavailableMap,
+                                userNameMap: userNameMap,
+                                scheduleId: widget.scheduleId,
+                                groupId: widget.groupId,
+                              ),
+                            ),
+                          );
+                        },
+                        child: const Text('스케줄 작성하러 가기'),
                       ),
-                    );
-                  },
-                  child: const Text('스케줄 작성하러 가기'),
-                ),
+                    ),
+                  ),
+                ],
               ),
-            ),
-          ],
-        ),
       ),
     );
   }

--- a/albamate_sample/lib/screen/groupPage/schedule/schdule_confirm_detail.dart
+++ b/albamate_sample/lib/screen/groupPage/schedule/schdule_confirm_detail.dart
@@ -30,6 +30,7 @@ class _ScheduleConfirmDetailPageState extends State<ScheduleConfirmDetailPage> {
     _parseSchedule();
   }
 
+
   void _parseSchedule() {
     final Map<String, dynamic> scheduleMap = json.decode(
       widget.scheduleMapJson,

--- a/albamate_sample/lib/screen/groupPage/schedule/schedule_card.dart
+++ b/albamate_sample/lib/screen/groupPage/schedule/schedule_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'worker_scheduleView.dart';
 import 'boss_scheduleView.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 
 class ScheduleCard extends StatelessWidget {
   final String title;
@@ -12,6 +13,7 @@ class ScheduleCard extends StatelessWidget {
   final int month;
   // TODO: ⚠️ 현재 userRole 임시 사용 중 (백엔드 ownerId 연동 시 제거 예정)
   final String userRole; // ✅ 역할 추가 ('사장님', '알바생')
+  final String groupId;
 
   const ScheduleCard({
     super.key,
@@ -23,6 +25,7 @@ class ScheduleCard extends StatelessWidget {
     required this.month,
     // TODO: ⚠️ 현재 userRole 임시 사용 중 (백엔드 ownerId 연동 시 제거 예정)
     required this.userRole, // ✅ 역할 받기
+    required this.groupId,
   });
 
   @override
@@ -49,12 +52,14 @@ class ScheduleCard extends StatelessWidget {
           ],
         ),
         onTap: () {
+          print('👀 전달된 역할: [$userRole]');
           if (userRole == '사장님') {
             Navigator.push(
               context,
               MaterialPageRoute(
                 builder:
                     (context) => BossScheduleViewPage(
+                      groupId: groupId,
                       scheduleId: scheduleId,
                       year: year,
                       month: month,
@@ -62,13 +67,21 @@ class ScheduleCard extends StatelessWidget {
               ),
             );
           } else if (userRole == '알바생') {
+            final user = FirebaseAuth.instance.currentUser; // firestore에서 uid가져옴
+            if (user == null) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('로그인이 필요합니다.')),
+            );
+            return;
+          }
+
             Navigator.push(
               context,
               MaterialPageRoute(
                 builder:
                     (context) => WorkerScheduleViewPage(
                       scheduleId: scheduleId,
-                      userId: 'dummy-user-id', // ✅ 나중에 실제 userId 전달
+                      userId: user.uid, //
                       year: year,
                       month: month,
                     ),

--- a/albamate_sample/lib/screen/groupPage/schedule/schedule_confirm_nav.dart
+++ b/albamate_sample/lib/screen/groupPage/schedule/schedule_confirm_nav.dart
@@ -1,6 +1,8 @@
+import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:albamate_sample/screen/groupPage/schedule/schdule_confirm_detail.dart';
 
 class ScheduleConfirmNav extends StatefulWidget {
@@ -8,29 +10,69 @@ class ScheduleConfirmNav extends StatefulWidget {
 
   const ScheduleConfirmNav({super.key, required this.groupId});
 
-  static final List<Map<String, dynamic>> confirmedSchedules = [];
-
-  static void addConfirmedSchedule(Map<String, dynamic> schedule) {
-    confirmedSchedules.add(schedule);
-  }
-
   @override
   State<ScheduleConfirmNav> createState() => _ScheduleConfirmNavState();
 }
 
 class _ScheduleConfirmNavState extends State<ScheduleConfirmNav> {
+  List<Map<String, dynamic>> confirmedSchedules = [];
+  bool isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    fetchConfirmedSchedules();
+  }
+
+  Future<void> fetchConfirmedSchedules() async {
+    final user = FirebaseAuth.instance.currentUser;
+    final idToken = await user?.getIdToken();
+
+    if (idToken == null) {
+      print('❗ 사용자 인증 토큰 없음');
+      return;
+    }
+
+    final response = await http.get(
+      Uri.parse(
+          'https://backend-schedule-vs8b.onrender.com/api/schedules/confirmed?groupId=${widget.groupId}'),
+      headers: {'Authorization': 'Bearer $idToken'},
+    );
+
+    if (response.statusCode == 200) {
+      final decoded = jsonDecode(response.body);
+      setState(() {
+        confirmedSchedules = List<Map<String, dynamic>>.from(decoded['data']);
+        isLoading = false;
+      });
+    } else {
+      print('❌ 서버 응답 실패: ${response.statusCode}');
+      setState(() {
+        isLoading = false;
+      });
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
+    if (isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (confirmedSchedules.isEmpty) {
+      return const Center(child: Text('확정된 스케줄이 없습니다.'));
+    }
+
     return ListView.builder(
       padding: const EdgeInsets.all(16.0),
-      itemCount: ScheduleConfirmNav.confirmedSchedules.length,
+      itemCount: confirmedSchedules.length,
       itemBuilder: (context, index) {
-        final schedule = ScheduleConfirmNav.confirmedSchedules[index];
-        final createdAt = schedule['createdAt'];
-        final createdAtFormatted = DateFormat('yyyy-MM-dd').format(
-          createdAt is DateTime
-              ? createdAt
-              : DateTime.tryParse(createdAt.toString()) ?? DateTime.now(),
+        final schedule = confirmedSchedules[index];
+        final confirmedAt = schedule['confirmedAt'];
+        final confirmedAtFormatted = DateFormat('yyyy-MM-dd').format(
+          confirmedAt is DateTime
+              ? confirmedAt
+              : DateTime.tryParse(confirmedAt.toString()) ?? DateTime.now(),
         );
 
         return Card(
@@ -39,23 +81,17 @@ class _ScheduleConfirmNavState extends State<ScheduleConfirmNav> {
           ),
           elevation: 3,
           child: ListTile(
-            title: Text(schedule['title'] ?? 'No Title'),
-            subtitle: Text('작성일: $createdAtFormatted'),
+            title: Text(schedule['confirmedTitle'] ?? '제목 없음'),
+            subtitle: Text('확정일: $confirmedAtFormatted'),
             onTap: () {
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder:
-                      (_) => ScheduleConfirmDetailPage(
-                        title: schedule['title'] ?? '',
-                        createdAt: createdAt.toString(),
-                        scheduleMapJson:
-                            schedule['scheduleMap'] is String
-                                ? schedule['scheduleMap']
-                                : jsonEncode(
-                                  schedule['scheduleMap'],
-                                ), // ✅ 이 부분 수정
-                      ),
+                  builder: (_) => ScheduleConfirmDetailPage(
+                    title: schedule['confirmedTitle'] ?? '',
+                    createdAt: confirmedAt.toString(),
+                    scheduleMapJson: jsonEncode(schedule['assignments']),
+                  ),
                 ),
               );
             },

--- a/albamate_sample/lib/screen/groupPage/schedule/worker_schedule_home.dart
+++ b/albamate_sample/lib/screen/groupPage/schedule/worker_schedule_home.dart
@@ -27,7 +27,7 @@ class _WorkerScheduleHomePageState extends State<WorkerScheduleHomePage> {
       ScheduleRequestNav(
         groupId: widget.groupId,
         // TODO: ⚠️ 현재 userRole 임시 사용 중 (백엔드 ownerId 연동 시 제거 예정)
-        userRole: '',
+        userRole: '알바생',
       ), // ✅ 요청 탭 (작성 불가, 보기만)
       ScheduleConfirmNav(groupId: widget.groupId), // ✅ 확정 스케줄 확인 탭
     ];

--- a/albamate_sample/lib/screen/homePage/worker/worker_card.dart
+++ b/albamate_sample/lib/screen/homePage/worker/worker_card.dart
@@ -30,7 +30,7 @@ class GroupCard extends StatelessWidget {
           Navigator.push(
             context,
             MaterialPageRoute(
-              builder: (context) => GroupNav(groupId: groupId, userRole: ''),
+              builder: (context) => GroupNav(groupId: groupId, userRole: '알바생'),
             ),
           );
         },


### PR DESCRIPTION
• 사용 기술 스택
  – Render, Docker, MongoDB Atlas, Node.js

• 구현 내용
  1. 사장님이 스케줄 작성 가능
  2. 알바생이 스케줄 게시글에서 날짜 선택 가능
    → 이후 다시 들어왔을 때, 본인이 선택한 날짜 확인 가능
  3. 사장님이 게시글 클릭 시, 알바생별 선택 날짜 확인 가능
  4. 사장님이 확정 게시글 작성시, 불가능 날짜를 선택한 알바생은 해당 날짜 목록에서 제외
    – 이때 알바생 목록은 ‘그룹 전체’가 아니라 해당 게시글에 참여한 인원 기준
  5. 스케줄 확정 시:
    – 기존 스케줄 게시글은 삭제됨
    – 확정된 스케줄은 확정 게시판으로 이동
  6. 확정 스케줄 게시판에서 확정 스케줄 조회 가능

-----------------------------------------------------------------------------------

• 팀원에게 알릴 사항
  – 확정 게시판의 체크박스는 아직 백엔드와 연동되어 있지 않음
  – 그룹 서버와 스케줄 서버가 분리되어 있어, 스케줄 화면에서도 로딩 시간이 다소 길 수 있습니다.. (그룹 참가 화면과 유사)