### PR TITLE
 worker 캘린더 /스케줄  사진 업로드 페이지

### DIFF
--- a/albamate_sample/lib/screen/homePage/worker/worker_homecalendar.dart
+++ b/albamate_sample/lib/screen/homePage/worker/worker_homecalendar.dart
@@ -4,6 +4,7 @@ import 'package:http/http.dart' as http;
 import 'dart:convert';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
+import 'worker_imageUpload.dart';
 
 //직원 캘린더
 class WorkerHomecalendar extends StatefulWidget {
@@ -150,6 +151,26 @@ class _WorkerHomecalendarState extends State<WorkerHomecalendar> {
                 6: FlexColumnWidth(),
               },
               children: _buildCalendarRows(daysInMonth),
+            ),
+            //사진 업로드 버튼
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                ElevatedButton.icon(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(builder: (context) => WorkerImageUploadPage()),
+                    );
+                  },
+                  icon: Icon(Icons.upload_file, color: Colors.white),
+                  label: Text("사진 업로드", style: TextStyle(color: Colors.white)),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Color(0xFF006FFD),
+                    padding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                  ),
+                ),
+              ],
             ),
           ],
         ),

--- a/albamate_sample/lib/screen/homePage/worker/worker_imageParseView.dart
+++ b/albamate_sample/lib/screen/homePage/worker/worker_imageParseView.dart
@@ -1,0 +1,83 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+
+class WorkerImageParseViewPage extends StatelessWidget {
+  final File imageFile;
+  final List<String> parsedSchedule;
+
+  const WorkerImageParseViewPage({
+    super.key,
+    required this.imageFile,
+    required this.parsedSchedule,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text("사진 검색"),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            //사진 크게 + 확대 가능
+            Container(
+              height: 320, // 사진 공간 더 크게
+              width: double.infinity,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(8),
+                color: Colors.grey.shade100,
+              ),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: InteractiveViewer(
+                  child: Image.file(
+                    imageFile,
+                    fit: BoxFit.contain,
+                  ),
+                ),
+              ),
+            ),
+
+            const SizedBox(height: 24),
+
+            // ====텍스트 추출 결과 (예정)===
+            Align(
+              alignment: Alignment.centerLeft,
+              child: Text("추출된 일정", style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+            ),
+            const SizedBox(height: 8),
+
+            // 리스트 출력
+            Expanded(
+              child: ListView.builder(
+                itemCount: parsedSchedule.length,
+                itemBuilder: (context, index) => Padding(
+                  padding: const EdgeInsets.only(bottom: 4),
+                  child: Text(parsedSchedule[index]),
+                ),
+              ),
+            ),
+
+            // 캘린더 연동 버튼
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: () {
+                  // 캘린더 반영 로직
+                },
+                child: Text("캘린더 연동"),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Color(0xFF006FFD),
+                  foregroundColor: Colors.white,
+                  padding: EdgeInsets.symmetric(vertical: 14),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/albamate_sample/lib/screen/homePage/worker/worker_imageUpload.dart
+++ b/albamate_sample/lib/screen/homePage/worker/worker_imageUpload.dart
@@ -1,0 +1,127 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'worker_imageParseView.dart';
+
+class WorkerImageUploadPage extends StatefulWidget {
+  const WorkerImageUploadPage({super.key});
+
+  @override
+  State<WorkerImageUploadPage> createState() => _WorkerImageUploadPageState();
+}
+
+class _WorkerImageUploadPageState extends State<WorkerImageUploadPage> {
+  File? _selectedImage;
+
+  // 이미지 선택 실행 함수
+  Future<void> _pickImage(ImageSource source) async {
+    final picker = ImagePicker();
+    final picked = await picker.pickImage(source: source);
+
+    if (picked != null) {
+      setState(() => _selectedImage = File(picked.path));
+
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) => WorkerImageParseViewPage(
+            imageFile: File(picked.path),
+            parsedSchedule: [
+              '텍스트 추출 넣을 예정'
+              // TODO: 여기 parsedSchedule은 추후 OCR API 결과로 대체될 예정
+              // 예: 서버에 이미지 업로드 → 일정 텍스트 추출 → 여기에 결과 넣기
+            ],
+          ),
+        ),
+      );
+    }
+  }
+
+
+  // 사진 선택 방식 모달
+  void _showImageSourceSelector(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      builder: (context) => SafeArea(
+        child: Wrap(
+          children: [
+            ListTile(
+              leading: Icon(Icons.camera_alt),
+              title: Text('사진 찍기'),
+              onTap: () {
+                Navigator.pop(context);
+                _pickImage(ImageSource.camera);
+              },
+            ),
+            ListTile(
+              leading: Icon(Icons.photo_library),
+              title: Text('사진 보관함'),
+              onTap: () {
+                Navigator.pop(context);
+                _pickImage(ImageSource.gallery);
+              },
+            ),
+            ListTile(
+              leading: Icon(Icons.close),
+              title: Text('취소'),
+              onTap: () => Navigator.pop(context),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text("이미지 업로드")),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              "스케줄표 사진을 업로드하고\n캘린더에 쉽게 연동하세요",
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 40),
+            Text("설명 이미지", style: TextStyle(fontSize: 14)),
+            const SizedBox(height: 8),
+            Container(
+              width: 120,
+              height: 120,
+              decoration: BoxDecoration(
+                color: Colors.grey.shade300,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: _selectedImage != null
+                  ? ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: Image.file(_selectedImage!, fit: BoxFit.cover),
+              )
+                  : Icon(Icons.image, size: 40, color: Colors.grey),
+            ),
+            const SizedBox(height: 60),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton.icon(
+                onPressed: () => _showImageSourceSelector(context),
+                icon: Icon(Icons.upload_file, color: Colors.white),
+                label: Text("사진 고르기", style: TextStyle(color: Colors.white)),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Color(0xFF006FFD),
+                  padding: EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## ✅ 주요 변경사항

- `worker_homecalendar.dart`
  - 알바생 캘린더에 사진업로드 버튼
- `worker_imageUpload.dart`
  - 스케줄표 이미지를 업로드할 수 있는 페이지
  - "사진 고르기" 버튼 클릭 시 사진 촬영 또는 사진 보관함 선택 가능
  - 업로드 후 `worker_imageParseView.dart`로 이동

- `worker_imageParseView.dart`
  - 업로드한 이미지와 추출된 텍스트(임시)를 함께 보여주는 뷰
  - 이미지 확대 가능, 캘린더 연동 버튼 추가
  - OCR API 연동 예정 부분 주석 처리
