### PR TITLE
일정 삭제 수정 + 그룹캘린더 사진업로드 

### DIFF
--- a/albamate_sample/lib/component/groupHome_navigation.dart
+++ b/albamate_sample/lib/component/groupHome_navigation.dart
@@ -10,15 +10,22 @@ import 'groupNotice_navigation.dart';
 class GroupNav extends StatefulWidget {
   final String groupId;
   final String userRole; // ✅ 현재 로그인 시 받은 '사장님' or '알바생'
+  final int initialIndex;
 
-  const GroupNav({super.key, required this.groupId, required this.userRole});
+  const GroupNav({super.key, required this.groupId, required this.userRole, required this.initialIndex});
 
   @override
   _GroupNavState createState() => _GroupNavState();
 }
 
 class _GroupNavState extends State<GroupNav> {
-  int _selectedIndex = 2;
+  late int _selectedIndex;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedIndex = widget.initialIndex; // ← 이거 추가!
+  }
 
   void _onItemTapped(int index) {
     setState(() {

--- a/albamate_sample/lib/screen/groupPage/group_imageConfirm.dart
+++ b/albamate_sample/lib/screen/groupPage/group_imageConfirm.dart
@@ -1,0 +1,71 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'group_imageProcessing.dart';
+
+class GroupImageConfirmPage extends StatelessWidget {
+  final File imageFile;
+  final String userRole;   // 👈 추가
+  final String groupId;    // 👈 추가
+
+  const GroupImageConfirmPage({
+    super.key,
+    required this.imageFile,
+    required this.userRole,
+    required this.groupId,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final h = MediaQuery.of(context).size.height;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('사진 확인')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            Container(
+              height: h * 0.55,
+              width: double.infinity,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(8),
+                color: Colors.grey.shade100,
+              ),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: Image.file(imageFile, fit: BoxFit.contain),
+              ),
+            ),
+            const SizedBox(height: 24),
+            const Text("이 사진에서 스케줄을 추출할까요?", style: TextStyle(fontSize: 16)),
+            const SizedBox(height: 16),
+            ElevatedButton.icon(
+              icon: const Icon(Icons.text_snippet),
+              label: const Text('스케줄 추출하기'),
+              onPressed: () {
+                Navigator.pushReplacement(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => GroupImageProcessingPage(
+                      imageFile: imageFile,
+                      userRole: userRole,
+                      groupId: groupId,
+                    ),
+                  ),
+                );
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFF006FFD),
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(
+                  vertical: 14,
+                  horizontal: 24,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/albamate_sample/lib/screen/groupPage/group_imageParseView.dart
+++ b/albamate_sample/lib/screen/groupPage/group_imageParseView.dart
@@ -1,0 +1,148 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'groupCalendar.dart';
+import 'group_imageProcessing.dart'; // Schedule 클래스 정의
+import 'package:albamate_sample/component/groupHome_navigation.dart';
+
+class GroupImageParseViewPage extends StatelessWidget {
+  final File imageFile;
+  final List<Schedule> schedules;
+  final String userRole;
+  final String groupId;
+
+  GroupImageParseViewPage({
+    super.key,
+    required this.imageFile,
+    required this.schedules,
+    required this.userRole,
+    required this.groupId,
+  });
+
+  String _fmt(TimeOfDay t) =>
+      '${t.hour.toString().padLeft(2, '0')}:${t.minute.toString().padLeft(2, '0')}';
+  final _dateFmt = DateFormat('M월 d일 (E)', 'ko');
+
+  @override
+  Widget build(BuildContext context) {
+    final h = MediaQuery.of(context).size.height;
+
+    // 이름 기준 그룹화
+    final Map<String, List<Schedule>> schedulesByName = {};
+    for (final s in schedules) {
+      schedulesByName.putIfAbsent(s.name, () => []).add(s);
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('스케줄 추출 결과')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            // 이미지 영역
+            Container(
+              height: h * 0.45,
+              width: double.infinity,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(8),
+                color: Colors.grey.shade100,
+              ),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: InteractiveViewer(
+                  child: Image.file(imageFile, fit: BoxFit.contain),
+                ),
+              ),
+            ),
+            const SizedBox(height: 24),
+
+            Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                '이름별 추출된 일정',
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+
+            // 이름별 일정 리스트
+            Expanded(
+              child: schedulesByName.isEmpty
+                  ? const Center(
+                child: Text(
+                  '추출된 일정이 없습니다.',
+                  style: TextStyle(color: Colors.grey),
+                ),
+              )
+                  : ListView(
+                children: schedulesByName.entries.map((entry) {
+                  final name = entry.key;
+                  final personSchedules = entry.value;
+
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const SizedBox(height: 12),
+                      Text(
+                        '👤 $name',
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      ...personSchedules.map((s) => ListTile(
+                        leading: const Icon(Icons.event_note),
+                        title: Text(
+                          '${_fmt(s.start)} ~ ${_fmt(s.end)}',
+                          style: const TextStyle(
+                              fontWeight: FontWeight.bold),
+                        ),
+                        subtitle: Text(
+                          '${_dateFmt.format(s.date)}  |  ${s.title}',
+                          softWrap: true,
+                        ),
+                        isThreeLine: true,
+                      )),
+                    ],
+                  );
+                }).toList(),
+              ),
+            ),
+            const SizedBox(height: 12),
+
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: () => Navigator.pushAndRemoveUntil(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => GroupNav(
+                      groupId: groupId,
+                      userRole: userRole,
+                      initialIndex: 3,
+                    ),
+                  ),
+                      (route) => false,
+                ),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFF006FFD),
+                  foregroundColor: Colors.white,
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+                child:
+                const Text('캘린더로 이동', style: TextStyle(fontSize: 16)),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/albamate_sample/lib/screen/groupPage/group_imageProcessing.dart
+++ b/albamate_sample/lib/screen/groupPage/group_imageProcessing.dart
@@ -1,0 +1,179 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:firebase_auth/firebase_auth.dart';
+import 'group_imageParseView.dart';
+
+
+class Schedule {
+  final DateTime date;
+  final TimeOfDay start;
+  final TimeOfDay end;
+  final String title;
+  final String name; // ✅ 추가
+
+  Schedule({
+    required this.date,
+    required this.start,
+    required this.end,
+    required this.title,
+    required this.name,
+  });
+
+  factory Schedule.fromJson(Map<String, dynamic> j) {
+    try {
+      TimeOfDay? _t(String? t) {
+        if (t == null || !t.contains(':')) return null;
+        final p = t.split(':').map(int.parse).toList();
+        return TimeOfDay(hour: p[0], minute: p[1]);
+      }
+
+      final dateStr = j['date'];
+      final date = dateStr != null ? DateTime.tryParse(dateStr) : null;
+      final start = _t(j['start']);
+      final end = _t(j['end']);
+
+      if (date == null || start == null || end == null) {
+        throw Exception('⛔ 필수 시간정보 누락');
+      }
+
+      return Schedule(
+        date: date,
+        start: start,
+        end: end,
+        title: j['title'] ?? '포지션 미지정',
+        name: j['name'] ?? '이름없음',
+      );
+    } catch (e) {
+      print('❗ Schedule 생성 실패: $e\nJSON: $j');
+      rethrow;
+    }
+  }
+
+  @override
+  String toString() {
+    final s =
+        '${start.hour.toString().padLeft(2, '0')}:${start.minute.toString().padLeft(2, '0')}';
+    final e =
+        '${end.hour.toString().padLeft(2, '0')}:${end.minute.toString().padLeft(2, '0')}';
+    return '${date.month}/${date.day}  $s-$e  $title ($name)';
+  }
+}
+
+class GroupImageProcessingPage extends StatefulWidget {
+  final File imageFile;
+  final String userRole;
+  final String groupId;
+
+  const GroupImageProcessingPage({
+    super.key,
+    required this.imageFile,
+    required this.userRole,
+    required this.groupId,
+  });
+
+  @override
+  State<GroupImageProcessingPage> createState() =>
+      _GroupImageProcessingPageState();
+}
+
+class _GroupImageProcessingPageState extends State<GroupImageProcessingPage> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _uploadAndParse();
+    });
+  }
+
+  Future<void> _uploadAndParse() async {
+    final user = FirebaseAuth.instance.currentUser;
+    final uid = user?.uid;
+
+    if (uid == null) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('로그인 정보가 없습니다.')),
+        );
+        Navigator.pop(context);
+      }
+      return;
+    }
+
+
+    try {
+      final req = http.MultipartRequest(
+        'POST',
+        Uri.parse('https://backend-vgbf.onrender.com/ocr/schedule'),// 백엔드 새로 필요
+      )
+        ..fields['user_uid'] = uid
+      // ✅ display_name 제거 → 전체 인물 스케줄 추출 가능
+        ..files.add(
+          await http.MultipartFile.fromPath('photo', widget.imageFile.path),
+        );
+
+      final res = await req.send();
+      final body = await res.stream.bytesToString();
+
+      if (res.statusCode != 200 && res.statusCode != 201) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('업로드 실패 (${res.statusCode})')),
+          );
+          Navigator.pop(context);
+        }
+        return;
+      }
+
+      final data = jsonDecode(body) as Map<String, dynamic>;
+
+      // ✅ 스케줄 파싱 + 실패 항목 무시
+      final List<Schedule> schedules = [];
+      for (final e in data['schedules'] ?? []) {
+        try {
+          schedules.add(Schedule.fromJson(e));
+        } catch (_) {}
+      }
+
+      if (mounted) {
+        Navigator.pushReplacement(
+          context,
+          MaterialPageRoute(
+            builder: (_) => GroupImageParseViewPage(
+              imageFile: widget.imageFile,
+              schedules: schedules,
+              userRole: widget.userRole,
+              groupId: widget.groupId,
+            ),
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('오류 발생: $e')),
+        );
+        Navigator.pop(context);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => const Scaffold(
+    backgroundColor: Colors.white,
+    body: Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          CircularProgressIndicator(),
+          SizedBox(height: 24),
+          Text(
+            '사진에서 일정을 추출 중입니다...',
+            style: TextStyle(fontSize: 16),
+          ),
+        ],
+      ),
+    ),
+  );
+}

--- a/albamate_sample/lib/screen/groupPage/group_imageUpload.dart
+++ b/albamate_sample/lib/screen/groupPage/group_imageUpload.dart
@@ -1,0 +1,138 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'group_imageConfirm.dart'; // 경로 확인
+
+class GroupImageUploadPage extends StatefulWidget {
+  final String userRole;
+  final String groupId;
+
+  const GroupImageUploadPage({
+    super.key,
+    required this.userRole,
+    required this.groupId,
+  });
+
+  @override
+  State<GroupImageUploadPage> createState() => _GroupImageUploadPageState();
+}
+
+class _GroupImageUploadPageState extends State<GroupImageUploadPage> {
+  File? _selectedImage;
+
+  // 이미지 선택 함수
+  Future<void> _pickImage(ImageSource source) async {
+    final picker = ImagePicker();
+    final picked = await picker.pickImage(source: source);
+
+    if (picked != null) {
+      setState(() => _selectedImage = File(picked.path));
+
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) => GroupImageConfirmPage(
+            imageFile: File(picked.path),
+            userRole: widget.userRole,
+            groupId: widget.groupId,
+          ),
+        ),
+      );
+    }
+  }
+
+  // 이미지 소스 선택 모달
+  void _showImageSourceSelector(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      builder: (context) => SafeArea(
+        child: Wrap(
+          children: [
+            ListTile(
+              leading: const Icon(Icons.camera_alt),
+              title: const Text('사진 찍기'),
+              onTap: () {
+                Navigator.pop(context);
+                _pickImage(ImageSource.camera);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.photo_library),
+              title: const Text('사진 보관함'),
+              onTap: () {
+                Navigator.pop(context);
+                _pickImage(ImageSource.gallery);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.close),
+              title: const Text('취소'),
+              onTap: () => Navigator.pop(context),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text("이미지 업로드")),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text(
+              "스케줄표 사진을 업로드하고\n캘린더에 쉽게 연동하세요",
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 50),
+
+            Image.asset(
+              'assets/images/schedule_ai_calendar.png',
+              width: 320,
+              fit: BoxFit.contain,
+            ),
+            const SizedBox(height: 18),
+
+            const Text(
+              "사진만 올리면, 일정이 자동으로 등록돼요!",
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 4),
+            const Text(
+              "예시처럼 스케줄표를 올려주세요",
+              style: TextStyle(fontSize: 14, color: Colors.grey),
+            ),
+            const SizedBox(height: 60),
+
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton.icon(
+                onPressed: () => _showImageSourceSelector(context),
+                icon: const Icon(Icons.upload_file, color: Colors.white),
+                label: const Text(
+                  "사진 고르기",
+                  style: TextStyle(fontSize: 18, color: Colors.white),
+                ),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFF006FFD),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 14,
+                  ),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/albamate_sample/lib/screen/groupPage/notice/guide/detail_guide_page.dart
+++ b/albamate_sample/lib/screen/groupPage/notice/guide/detail_guide_page.dart
@@ -99,6 +99,7 @@ class _DetailGuidePageState extends State<DetailGuidePage> {
                         groupId: widget.notice.groupId,
                         // TODO: ⚠️ 현재 userRole 임시 사용 중 (백엔드 ownerId 연동 시 제거 예정)
                         userRole: '',
+                        initialIndex: 2,
                       ),
                 ),
                 (Route<dynamic> route) => false,

--- a/albamate_sample/lib/screen/groupPage/notice/menu/detail_menu_page.dart
+++ b/albamate_sample/lib/screen/groupPage/notice/menu/detail_menu_page.dart
@@ -100,6 +100,7 @@ class _DetailMenuPageState extends State<DetailMenuPage> {
                         groupId: widget.notice.groupId,
                         // TODO: ⚠️ 현재 userRole 임시 사용 중 (백엔드 ownerId 연동 시 제거 예정)
                         userRole: '',
+                        initialIndex: 2,
                       ),
                 ),
                 (Route<dynamic> route) => false,

--- a/albamate_sample/lib/screen/groupPage/notice/sub/detail_sub_page.dart
+++ b/albamate_sample/lib/screen/groupPage/notice/sub/detail_sub_page.dart
@@ -186,6 +186,7 @@ class _DetailSubPageState extends State<DetailSubPage> {
                         groupId: widget.notice.groupId,
                         // TODO: ⚠️ 현재 userRole 임시 사용 중 (백엔드 ownerId 연동 시 제거 예정)
                         userRole: '',
+                        initialIndex: 2,
                       ),
                 ),
                 (Route<dynamic> route) => false,

--- a/albamate_sample/lib/screen/homePage/boss/boss_homeCalendar.dart
+++ b/albamate_sample/lib/screen/homePage/boss/boss_homeCalendar.dart
@@ -256,93 +256,114 @@ class _BossHomecalendarState extends State<BossHomecalendar> {
 
   //해당 날짜 일정 상세 보기
   void _showDayDetailSheet(DateTime date) {
-    final dayAppointments = _events[date] ?? [];
-
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
       builder: (context) => DraggableScrollableSheet(
         expand: false,
-        builder: (context, scrollController) => Scaffold(
-          appBar: AppBar(
-            title: Text("${date.month}월 ${date.day}일 일정"),
-            actions: [
-              IconButton(
-                icon: Icon(Icons.add),
-                onPressed: () {
-                  Navigator.pop(context);
-                  _showAddDialog(date);
-                },
-              ),
-            ],
-          ),
-          body: ListView.builder(
-            controller: scrollController,
-            itemCount: dayAppointments.length,
-            itemBuilder: (context, index) {
-              final appt = dayAppointments[index];
-              return Slidable(
-                key: ValueKey(appt.notes ?? '${appt.subject}-$index'),
-                endActionPane: ActionPane(
-                  motion: const ScrollMotion(), // ✅ 진짜 슬라이드 효과
-                  extentRatio: 0.4, // 두 버튼 공간
-                  children: [
-                    //수정 버튼
-                    SlidableAction(
-                      flex:1,
-                      onPressed: (_) {
-                        Navigator.pop(context);
-                        _showEditDialog(appt);
-                      },
-                      backgroundColor: Colors.blue.shade50,
-                      foregroundColor: Colors.blue,
-                      icon: Icons.edit_outlined,
-                      borderRadius: BorderRadius.circular(8),
+        builder: (context, scrollController) => StatefulBuilder(
+          builder: (context, setSheetState) => Scaffold(
+            appBar: AppBar(
+              title: Text("${date.month}월 ${date.day}일 일정"),
+              actions: [
+                IconButton(
+                  icon: Icon(Icons.add),
+                  onPressed: () {
+                    Navigator.pop(context);
+                    _showAddDialog(date);
+                  },
+                ),
+              ],
+            ),
+            body: ListView.builder(
+              controller: scrollController,
+              itemCount: _events[date]?.length ?? 0,
+              itemBuilder: (context, index) {
+                final appt = _events[date]![index];
 
+                return Slidable(
+                  key: ValueKey(appt.notes ?? '${appt.subject}-$index'),
+                  endActionPane: ActionPane(
+                    motion: const ScrollMotion(),
+                    extentRatio: 0.4,
+                    children: [
+                      SlidableAction(
+                        flex: 1,
+                        onPressed: (_) {
+                          Navigator.pop(context);
+                          _showEditDialog(appt);
+                        },
+                        backgroundColor: Colors.blue.shade50,
+                        foregroundColor: Colors.blue,
+                        icon: Icons.edit_outlined,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      SlidableAction(
+                        flex: 1,
+                        onPressed: (_) async {
+                          final response = await http.delete(
+                            Uri.parse('https://backend-vgbf.onrender.com/appointments/${appt.notes}'),
+                          );
+
+                          if (response.statusCode == 204 && mounted) {
+                            final dateKey = DateTime(
+                              appt.startTime.year,
+                              appt.startTime.month,
+                              appt.startTime.day,
+                            );
+
+                            setState(() {
+                              _appointments.removeWhere((a) => a.notes == appt.notes);
+
+                              final updatedDayList = _appointments.where((a) =>
+                              a.startTime.year == dateKey.year &&
+                                  a.startTime.month == dateKey.month &&
+                                  a.startTime.day == dateKey.day,
+                              ).toList();
+
+                              if (updatedDayList.isEmpty) {
+                                _events.remove(dateKey);
+                              } else {
+                                _events[dateKey] = updatedDayList;
+                              }
+                            });
+
+                            // ✅ UI 목록도 갱신
+                            setSheetState(() {});
+                          }
+                        },
+                        backgroundColor: Colors.red.shade50,
+                        foregroundColor: Colors.red,
+                        icon: Icons.delete_outline,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ],
+                  ),
+                  child: ListTile(
+                    contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                    leading: Container(
+                      width: 12,
+                      height: 12,
+                      decoration: BoxDecoration(
+                        color: appt.color,
+                        shape: BoxShape.rectangle,
+                        borderRadius: BorderRadius.circular(2),
+                      ),
                     ),
-                    //삭제 버튼
-                    SlidableAction(
-                      flex: 1,
-                      onPressed: (_) async {
-                        final response = await http.delete(
-                          Uri.parse('https://backend-vgbf.onrender.com/appointments/${appt.notes}'),
-                        );
-                        if (response.statusCode == 204) {
-                          setState(() => _appointments.remove(appt));
-                          _fetchAppointments(); //다시 불러오기
-                        }
-                        Navigator.pop(context);
-                      },
-                      backgroundColor: Colors.red.shade50,
-                      foregroundColor: Colors.red,
-                      icon: Icons.delete_outline,
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                  ],
-                ),
-                child: ListTile(
-                  contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-                  leading: Container(
-                    width: 12,
-                    height: 12,
-                    decoration: BoxDecoration(
-                      color: appt.color,
-                      shape: BoxShape.rectangle,
-                      borderRadius: BorderRadius.circular(2),
+                    title: Text(
+                      appt.subject,
+                      style: TextStyle(fontSize: 14),
                     ),
                   ),
-                  title: Text(
-                    appt.subject,
-                    style: TextStyle(fontSize: 14),
-                  ),
-                ),
-              );
-            },
+                );
+              },
+            ),
           ),
         ),
       ),
     );
   }
+
   //일정 추가 다이얼로그
   void _showAddDialog(DateTime selectedDate) {
     String title = "";

--- a/albamate_sample/lib/screen/homePage/boss/group_card.dart
+++ b/albamate_sample/lib/screen/homePage/boss/group_card.dart
@@ -72,7 +72,7 @@ class GroupCard extends StatelessWidget {
               MaterialPageRoute(
                 // 사장님뷰로만 확인 가능
                 builder:
-                    (context) => GroupNav(groupId: groupId, userRole: '사장님'),
+                    (context) => GroupNav(groupId: groupId, userRole: '사장님',initialIndex: 2),
               ),
             );
           },

--- a/albamate_sample/lib/screen/homePage/worker/worker_card.dart
+++ b/albamate_sample/lib/screen/homePage/worker/worker_card.dart
@@ -30,7 +30,7 @@ class GroupCard extends StatelessWidget {
           Navigator.push(
             context,
             MaterialPageRoute(
-              builder: (context) => GroupNav(groupId: groupId, userRole: '알바생'),
+              builder: (context) => GroupNav(groupId: groupId, userRole: '알바생', initialIndex: 2),
             ),
           );
         },


### PR DESCRIPTION
1. 그룹 캘린더 , 개인(사장, 직원) 캘린더 모두 일정 삭제 새로고침 부분 수정 완료
+ 그룹 캘린더에서 사장님만 일정 수정, 등록할 수 있는데 이때 api 아직 없어요

2. 그룹캘린더 사진업로드 부분
- group_imageUpload.dart → group_imageConfirm.dart → group_imageProcessing.dart → group_imageParseView.dart
- 사장님 계정에서만 GroupCalendarPage 상단 버튼 노출
- group_imageParseView 에서 그룹캘린더로 다시 돌아갈때, GroupCalendarPage push 를 통해 이동하면 네비게이션 바가 보이지 않는 문제점이 생겨서 GroupNav에 인덱스를 추가했어요 
+ 백엔드 연동 관련 사항 (추가 작업 필요)
