### PR TITLE
Gemini 파라미터 정적에서 동적으로 변경(테스트해보니 파라미터 적용안되었음) + Gemini 2.5 Flash Lite로 변경 + 재시도 로직 추가

### DIFF
--- a/CLOVA_INTEGRATION.md
+++ b/CLOVA_INTEGRATION.md
@@ -1,8 +1,8 @@
-# Clova OCR + Gemini 2.0 Flash 프론트엔드 연동 가이드
+# Clova OCR + Gemini 2.5 Flash Lite 프론트엔드 연동 가이드
 
 ## 개요
 
-Flutter 앱에서 Clova OCR과 Gemini 2.0 Flash를 통해 스케줄 이미지를 업로드하고 자동으로 일정을 등록하는 방법입니다.
+Flutter 앱에서 Clova OCR과 Gemini 2.5 Flash Lite를 통해 스케줄 이미지를 업로드하고 자동으로 일정을 등록하는 방법입니다.
 
 ## API 사용법
 
@@ -20,7 +20,7 @@ class OcrService {
     required File imageFile,
     required String userUid,
     String? displayName,
-    bool useGemini = true, // Gemini 2.0 Flash 사용 여부
+    bool useGemini = true, // Gemini 2.5 Flash Lite 사용 여부
   }) async {
     try {
       // multipart 요청 생성
@@ -299,7 +299,7 @@ class _ScheduleUploadWidgetState extends State<ScheduleUploadWidget> {
                   children: [
                     Expanded(
                       child: RadioListTile<bool>(
-                        title: Text('🤖 Gemini 2.0 Flash'),
+                        title: Text('🤖 Gemini 2.5 Flash Lite'),
                         subtitle: Text('더 정확한 분석'),
                         value: true,
                         groupValue: _useGemini,
@@ -393,7 +393,7 @@ class _ScheduleUploadWidgetState extends State<ScheduleUploadWidget> {
 2. **파일 크기**: 너무 큰 이미지는 업로드 시간이 오래 걸릴 수 있습니다
 3. **네트워크**: 안정적인 인터넷 연결이 필요합니다
 4. **권한**: 갤러리 접근 권한이 필요합니다
-5. **API 키**: Gemini 2.0 Flash 사용 시 Google AI Studio API 키가 필요합니다
+5. **API 키**: Gemini 2.5 Flash Lite 사용 시 Google AI Studio API 키가 필요합니다
 
 ## 에러 처리
 

--- a/albamate_sample/lib/screen/homePage/worker/worker_imageParseView.dart
+++ b/albamate_sample/lib/screen/homePage/worker/worker_imageParseView.dart
@@ -46,7 +46,7 @@ class WorkerImageParseViewPage extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         const Text(
-                          '🤖 Gemini 2.0 Flash AI 분석',
+                          '🤖 Gemini 2.5 Flash Lite AI 분석',
                           style: TextStyle(
                             fontWeight: FontWeight.bold,
                             color: Color(0xFF006FFD),

--- a/albamate_sample/lib/screen/homePage/worker/worker_imageProcessing.dart
+++ b/albamate_sample/lib/screen/homePage/worker/worker_imageProcessing.dart
@@ -120,6 +120,10 @@ class _WorkerImageProcessingPageState extends State<WorkerImageProcessingPage> {
             )
             ..fields['user_uid'] = uid
             ..fields['display_name'] = finalName
+            ..fields['use_gemini'] = 'true'
+            ..fields['gemini_seed'] = '12345'  // 고정된 seed 값
+            ..fields['gemini_temperature'] = '0.1'  // 낮은 temperature
+            ..fields['gemini_top_p'] = '0.8'  // 기본 topP 값
             ..files.add(
               await http.MultipartFile.fromPath('photo', widget.imageFile.path),
             );
@@ -129,6 +133,9 @@ class _WorkerImageProcessingPageState extends State<WorkerImageProcessingPage> {
       print('   URL: ${req.url}');
       print('   user_uid: $uid');
       print('   display_name: $finalName');
+      print('   gemini_seed: 12345');
+      print('   gemini_temperature: 0.1');
+      print('   gemini_top_p: 0.8');
       print('   image_path: ${widget.imageFile.path}');
       print('   image_size: ${await widget.imageFile.length()} bytes');
 

--- a/albamate_sample/lib/screen/homePage/worker/worker_imageProcessing.dart
+++ b/albamate_sample/lib/screen/homePage/worker/worker_imageProcessing.dart
@@ -120,10 +120,10 @@ class _WorkerImageProcessingPageState extends State<WorkerImageProcessingPage> {
             )
             ..fields['user_uid'] = uid
             ..fields['display_name'] = finalName
-            ..fields['use_gemini'] = 'true'
-            ..fields['gemini_seed'] = '12345'  // 고정된 seed 값
-            ..fields['gemini_temperature'] = '0.1'  // 낮은 temperature
-            ..fields['gemini_top_p'] = '0.8'  // 기본 topP 값
+            ..fields['use_gemini'] = 'true' 
+            ..fields['gemini_seed'] = '12345'  // 고정된 seed 값 
+            ..fields['gemini_temperature'] = '0.1'  // 낮은 temperature 
+            ..fields['gemini_top_p'] = '0.9'  // 기본 topP 값 
             ..files.add(
               await http.MultipartFile.fromPath('photo', widget.imageFile.path),
             );

--- a/albamate_sample/lib/screen/homePage/worker/worker_imageProcessing.dart
+++ b/albamate_sample/lib/screen/homePage/worker/worker_imageProcessing.dart
@@ -164,6 +164,13 @@ class _WorkerImageProcessingPageState extends State<WorkerImageProcessingPage> {
       // 디버깅: 응답 데이터 확인
       print('🔍 백엔드 응답: $data');
       
+      // 재시도 정보 확인
+      if (data['retry_info'] != null) {
+        print('🔄 재시도 정보:');
+        print('   최대 재시도 횟수: ${data['retry_info']['max_retries']}');
+        print('   재시도 과정: ${data['retry_info']['retry_attempts']}');
+      }
+      
       final List<Schedule> schedules = [];
       
       if (data['schedules'] != null) {

--- a/albamate_sample/lib/screen/homePage/worker/worker_imageProcessing.dart
+++ b/albamate_sample/lib/screen/homePage/worker/worker_imageProcessing.dart
@@ -120,10 +120,11 @@ class _WorkerImageProcessingPageState extends State<WorkerImageProcessingPage> {
             )
             ..fields['user_uid'] = uid
             ..fields['display_name'] = finalName
-            ..fields['use_gemini'] = 'true' 
-            ..fields['gemini_seed'] = '12345'  // 고정된 seed 값 
-            ..fields['gemini_temperature'] = '0.1'  // 낮은 temperature 
-            ..fields['gemini_top_p'] = '0.9'  // 기본 topP 값 
+            ..fields['use_gemini'] = 'true'
+            ..fields['gemini_seed'] = '12345'  // 고정된 seed 값
+            ..fields['gemini_temperature'] = '0.1'  // 낮은 temperature
+            ..fields['gemini_top_p'] = '0.8'  // 기본 topP 값
+            ..fields['max_retries'] = '3'  // 최대 재시도 횟수
             ..files.add(
               await http.MultipartFile.fromPath('photo', widget.imageFile.path),
             );
@@ -136,6 +137,7 @@ class _WorkerImageProcessingPageState extends State<WorkerImageProcessingPage> {
       print('   gemini_seed: 12345');
       print('   gemini_temperature: 0.1');
       print('   gemini_top_p: 0.8');
+      print('   max_retries: 3');
       print('   image_path: ${widget.imageFile.path}');
       print('   image_size: ${await widget.imageFile.length()} bytes');
 

--- a/albamate_sample/lib/screen/homePage/worker/worker_imageProcessing.dart
+++ b/albamate_sample/lib/screen/homePage/worker/worker_imageProcessing.dart
@@ -121,7 +121,7 @@ class _WorkerImageProcessingPageState extends State<WorkerImageProcessingPage> {
             ..fields['user_uid'] = uid
             ..fields['display_name'] = finalName
             ..fields['use_gemini'] = 'true'
-            ..fields['gemini_seed'] = '12345'  // 고정된 seed 값
+            ..fields['gemini_seed'] = '1000'  // 고정된 seed 값
             ..fields['gemini_temperature'] = '0.1'  // 낮은 temperature
             ..fields['gemini_top_p'] = '0.3'  // 낮은 topP 값
             ..fields['max_retries'] = '3'  // 최대 재시도 횟수

--- a/albamate_sample/lib/screen/homePage/worker/worker_imageProcessing.dart
+++ b/albamate_sample/lib/screen/homePage/worker/worker_imageProcessing.dart
@@ -123,7 +123,7 @@ class _WorkerImageProcessingPageState extends State<WorkerImageProcessingPage> {
             ..fields['use_gemini'] = 'true'
             ..fields['gemini_seed'] = '12345'  // 고정된 seed 값
             ..fields['gemini_temperature'] = '0.1'  // 낮은 temperature
-            ..fields['gemini_top_p'] = '0.8'  // 기본 topP 값
+            ..fields['gemini_top_p'] = '0.3'  // 낮은 topP 값
             ..fields['max_retries'] = '3'  // 최대 재시도 횟수
             ..files.add(
               await http.MultipartFile.fromPath('photo', widget.imageFile.path),
@@ -136,7 +136,7 @@ class _WorkerImageProcessingPageState extends State<WorkerImageProcessingPage> {
       print('   display_name: $finalName');
       print('   gemini_seed: 12345');
       print('   gemini_temperature: 0.1');
-      print('   gemini_top_p: 0.8');
+      print('   gemini_top_p: 0.3');
       print('   max_retries: 3');
       print('   image_path: ${widget.imageFile.path}');
       print('   image_size: ${await widget.imageFile.length()} bytes');

--- a/albamate_sample/lib/screen/homePage/worker/worker_imageProcessing.dart
+++ b/albamate_sample/lib/screen/homePage/worker/worker_imageProcessing.dart
@@ -87,7 +87,7 @@ class _WorkerImageProcessingPageState extends State<WorkerImageProcessingPage> {
       builder: (context) {
         return AlertDialog(
           title: const Text('스케줄 추출 이름 확인'),
-          content: Text('$name 님의 스케줄을 추출할까요?\n\n🤖 Gemini 2.0 Flash AI가 정확하게 분석합니다.'),
+          content: Text('$name 님의 스케줄을 추출할까요?\n\n🤖 Gemini 2.5 Flash Lite AI가 정확하게 분석합니다.'),
           actions: [
             TextButton(
               child: const Text('아니오'),
@@ -112,7 +112,7 @@ class _WorkerImageProcessingPageState extends State<WorkerImageProcessingPage> {
     if (finalName == null || finalName.trim().isEmpty) return;
 
     try {
-      // 🤖 Gemini 2.0 Flash 전용 엔드포인트 사용
+      // 🤖 Gemini 2.5 Flash Lite 전용 엔드포인트 사용
       final req =
           http.MultipartRequest(
               'POST',


### PR DESCRIPTION
# 🔧 Gemini 파라미터 동적 설정 + Flash Lite 2.5 업그레이드 + 재시도 로직 추가
Fix #59

## 개요
Gemini AI 모델의 파라미터(seed, temperature, topP)를 동적으로 설정할 수 있도록 개선하여, 동일한 입력에 대해 일관된 결과를 얻을 수 있게 했습니다.
Gemini 2.0 Flash → Gemini 2.5 Flash Lite로 업그레이드하여 더 빠르고 정확한 일정 추출이 가능해졌습니다.
OCR+LLM 추출 실패 시 자동 재시도 로직을 추가하여 성공률과 안정성을 높였습니다.

## 주요 변경사항
### 1. GeminiService.js
문제: 전역 모델 인스턴스 사용으로 파라미터 변경 불가, 모델 버전 구식
해결: 함수 호출 시마다 동적으로 모델 생성, 최신 모델(gemini-2.5-flash-lite)로 변경
추가: 상세한 디버깅 로그, 재시도 로직(최대 3회, 파라미터 점진적 변경)
Apply to geminiServic...

### 2. OCR Controller
추가: Gemini 파라미터 및 재시도 횟수를 요청에서 받을 수 있도록 수정
개선: 파라미터 검증 및 로깅 강화
Apply to geminiServic...

### 3. Flutter 앱
추가: Gemini 파라미터 및 재시도 횟수 전달
개선: 요청 정보 로깅 강화
Apply to geminiServic...

### 4. 기타
문서/주석/로그: Gemini 2.0 Flash → Gemini 2.5 Flash Lite로 전면 교체
테스트 파일: 재시도 로직 검증용 테스트 스크립트(test-retry.js)는 실제 배포에서 제외

### 테스트 시나리오
기존 문제
동일한 이미지 업로드 시 결과가 일관되지 않음
첫 번째: 3개 일정 파싱 성공
두 번째: 0개 일정 파싱 (실패)
세 번째: 0개 일정 파싱 (실패)
네 번째: 2개 일정 파싱 성공

### 개선 후 기대 효과
동일한 이미지 + 동일한 파라미터 = 일관된 결과
Postman에서 다양한 파라미터 조합 테스트 가능
디버깅 로그로 문제 추적 용이
추출 실패 시 자동 재시도 → 성공률 향상
일정이 0개 추출될 시, 재시도 로직 3번 실행

### 📊 API 엔드포인트 변경사항
POST /ocr/schedule

### 새로운 파라미터 추가:
gemini_seed (선택, 기본값: "12345")
gemini_temperature (선택, 기본값: "0.1")
gemini_top_p (선택, 기본값: "0.8")
max_retries (선택, 기본값: "3")
예시 요청:
Apply to geminiServic...
Run

### ✅ 검증 방법
동일 이미지 반복 테스트: 같은 근무표 이미지를 3-4번 업로드, 모든 결과가 동일한지 확인
Postman 파라미터 테스트: 다양한 seed/temperature/topP/max_retries 값 조합 테스트
로그 확인: 백엔드 로그에서 파라미터 전달 및 Gemini 응답 일관성 확인

### 배포 영향
호환성: 기존 API와 완전 호환 (기본값 유지)
성능: 미미한 영향 (모델 생성 오버헤드)
안정성: 향상된 일관성, 자동 재시도로 성공률 증가

### 체크리스트
[x] GeminiService.js 파라미터 동적 설정 및 재시도 로직
[x] OCR Controller 파라미터 수신 및 전달
[x] Flutter 앱 파라미터 전달
[x] 디버깅 로그 추가
[x] API 문서/주석/로그 업데이트
[x] 테스트 시나리오 작성 및 검증