### PR TITLE
ai 요약 기능 추가, 제목 자동 생성 추가

### DIFF
--- a/albamate_sample/lib/screen/groupPage/notice/guide/autoCreateGuide.dart
+++ b/albamate_sample/lib/screen/groupPage/notice/guide/autoCreateGuide.dart
@@ -56,12 +56,22 @@ class _AutoCreateGuidePageState extends State<AutoCreateGuidePage> {
       _previousText = null;
     });
   }
-
+   // 제목과 본문 넘기기
   void _applyToPreviousPage() {
-    if (_generatedText != null) {
-      Navigator.pop(context, _generatedText);
-    }
+  if (_generatedText == null) return;
+
+  final result = _generatedText!;
+  final title = RegExp(r'제목:\s*(.*)').firstMatch(result)?.group(1)?.trim();
+  final content = RegExp(r'본문:\s*(.*)', dotAll: true).firstMatch(result)?.group(1)?.trim();
+
+  if (title != null && content != null) {
+    Navigator.pop(context, {
+      'title': title,
+      'content': content,
+    });
   }
+}
+
 
   List<String> _extractTagsFromInput() {
     return _inputController.text
@@ -148,15 +158,51 @@ class _AutoCreateGuidePageState extends State<AutoCreateGuidePage> {
                         decoration: BoxDecoration(
                           color: Colors.grey[100],
                           borderRadius: BorderRadius.circular(8),
+                            boxShadow: [
+                              BoxShadow(color: Colors.black12, blurRadius: 4, offset: Offset(0, 2)),
+                            ],
                         ),
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             Text("AI 생성 결과", style: TextStyle(fontWeight: FontWeight.bold)),
                             SizedBox(height: 8),
-                            Text(_generatedText!),
-                            SizedBox(height: 12),
+                            // 제목 박스
+                            Text("제목", style: TextStyle(color: Colors.grey[600], fontSize: 14)),
+                            SizedBox(height: 4),
+                            Container(
+                              width: double.infinity,
+                              padding: EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+                              decoration: BoxDecoration(
+                                color: Colors.white,
+                                border: Border.all(color: Colors.blueAccent.withOpacity(0.5)),
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                              child: Text(
+                                RegExp(r'제목:\s*(.*)').firstMatch(_generatedText!)?.group(1) ?? '제목 없음',
+                              ),
+                            ),
 
+                            SizedBox(height: 12),
+                            // 본문
+                            Text("본문", style: TextStyle(color: Colors.grey[600], fontSize: 14)),
+                            SizedBox(height: 4),
+                            Container(
+                              width: double.infinity,
+                              padding: EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+                              decoration: BoxDecoration(
+                                color: Colors.white,
+                                border: Border.all(color: Colors.blueAccent.withOpacity(0.5)),
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                              child: Text(
+                                RegExp(r'본문:\s*(.*)', dotAll: true).firstMatch(_generatedText!)?.group(1)?.trim() ?? '본문 없음',
+                                style: TextStyle(fontSize: 16, height: 1.6),
+                              ),
+                            ),
+
+
+                            SizedBox(height: 12),
                             // 태그 표시
                             Wrap(
                               spacing: 6,

--- a/albamate_sample/lib/screen/groupPage/notice/guide/create_guide_page.dart
+++ b/albamate_sample/lib/screen/groupPage/notice/guide/create_guide_page.dart
@@ -187,16 +187,18 @@ class _CreateGuidePageState extends State<CreateGuidePage> {
                 ),
                 ElevatedButton(
                   onPressed: () async {
-                    final result = await Navigator.push(
+                    final result = await Navigator.push<Map<String, String>>(
                       context,
                       MaterialPageRoute(builder: (_) => AutoCreateGuidePage()),
                     );
-                    if (result != null && result is String) {
+                    if (result != null) {
                       setState(() {
-                        _contentController.text = result;
+                        _titleController.text = result['title'] ?? '';
+                        _contentController.text = result['content'] ?? '';
                       });
                     }
                   },
+
                   style: ElevatedButton.styleFrom(
                     backgroundColor: Color(0xFF006FFD),
                   ),

--- a/albamate_sample/lib/screen/groupPage/notice/menu/autoCreateMenu.dart
+++ b/albamate_sample/lib/screen/groupPage/notice/menu/autoCreateMenu.dart
@@ -57,11 +57,22 @@ class _AutoCreateMenuPageState extends State<AutoCreateMenuPage> {
     });
   }
 
+  // 제목과 본문 넘기기
   void _applyToPreviousPage() {
-    if (_generatedText != null) {
-      Navigator.pop(context, _generatedText);
-    }
+  if (_generatedText == null) return;
+
+  final result = _generatedText!;
+  final title = RegExp(r'제목:\s*(.*)').firstMatch(result)?.group(1)?.trim();
+  final content = RegExp(r'본문:\s*(.*)', dotAll: true).firstMatch(result)?.group(1)?.trim();
+
+  if (title != null && content != null) {
+    Navigator.pop(context, {
+      'title': title,
+      'content': content,
+    });
   }
+}
+
 
   List<String> _extractTagsFromInput() {
     return _inputController.text
@@ -148,15 +159,51 @@ class _AutoCreateMenuPageState extends State<AutoCreateMenuPage> {
                         decoration: BoxDecoration(
                           color: Colors.grey[100],
                           borderRadius: BorderRadius.circular(8),
+                            boxShadow: [
+                              BoxShadow(color: Colors.black12, blurRadius: 4, offset: Offset(0, 2)),
+                            ],
                         ),
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             Text("AI 생성 결과", style: TextStyle(fontWeight: FontWeight.bold)),
                             SizedBox(height: 8),
-                            Text(_generatedText!),
-                            SizedBox(height: 12),
+                            // 제목 박스
+                            Text("제목", style: TextStyle(color: Colors.grey[600], fontSize: 14)),
+                            SizedBox(height: 4),
+                            Container(
+                              width: double.infinity,
+                              padding: EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+                              decoration: BoxDecoration(
+                                color: Colors.white,
+                                border: Border.all(color: Colors.blueAccent.withOpacity(0.5)),
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                              child: Text(
+                                RegExp(r'제목:\s*(.*)').firstMatch(_generatedText!)?.group(1) ?? '제목 없음',
+                              ),
+                            ),
 
+                            SizedBox(height: 12),
+                            // 본문
+                            Text("본문", style: TextStyle(color: Colors.grey[600], fontSize: 14)),
+                            SizedBox(height: 4),
+                            Container(
+                              width: double.infinity,
+                              padding: EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+                              decoration: BoxDecoration(
+                                color: Colors.white,
+                                border: Border.all(color: Colors.blueAccent.withOpacity(0.5)),
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                              child: Text(
+                                RegExp(r'본문:\s*(.*)', dotAll: true).firstMatch(_generatedText!)?.group(1)?.trim() ?? '본문 없음',
+                                style: TextStyle(fontSize: 16, height: 1.6),
+                              ),
+                            ),
+
+
+                            SizedBox(height: 12),
                             // 태그 표시
                             Wrap(
                               spacing: 6,

--- a/albamate_sample/lib/screen/groupPage/notice/menu/create_menu_page.dart
+++ b/albamate_sample/lib/screen/groupPage/notice/menu/create_menu_page.dart
@@ -187,13 +187,14 @@ class _CreateMenuPageState extends State<CreateMenuPage> {
                 ),
                 ElevatedButton(
                   onPressed: () async {
-                    final result = await Navigator.push(
+                    final result = await Navigator.push<Map<String, String>>(
                       context,
                       MaterialPageRoute(builder: (_) => AutoCreateMenuPage()),
                     );
-                    if (result != null && result is String) {
+                    if (result != null) {
                       setState(() {
-                        _contentController.text = result;
+                        _titleController.text = result['title'] ?? '';
+                        _contentController.text = result['content'] ?? '';
                       });
                     }
                   },


### PR DESCRIPTION
✅공지사항 / 신메뉴 상세페이지 요약 기능 추가
- 요약하기 버튼 클릭 시 Gemini 기반 요약 API(/notice/llmSummary) 호출
- 요약 내용은 상단에 AnimatedCrossFade로 표시
- 버튼 클릭 시 요약 숨기기 / 다시 보기 전환 가능

✅AI 생성 결과 UI 개선
- 기존 AI 응답 텍스트에서 제목: / 본문: 포맷 자동 추출
- 추출된 제목/본문을 AutoCreateGuidePage, AutoCreateMenuPage에서 시각적으로 구분 표시
- 글 생성 완료 시, Navigator.pop()으로 각각 title/content 분리 전달

✅공지사항 / 신메뉴 작성 페이지 반영
- AI 생성 화면에서 받아온 제목, 본문을 각각 제목/본문 텍스트 필드에 자동 삽입되도록 수정
