### PR TITLE
Kimshyuno3

### DIFF
--- a/albamate_sample/lib/main.dart
+++ b/albamate_sample/lib/main.dart
@@ -4,6 +4,8 @@ import 'package:intl/date_symbol_data_local.dart'; // 추가
 import 'firebase_options.dart';
 import 'screen/onboarding.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/intl.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -37,6 +39,26 @@ class MyApp extends StatelessWidget {
         // fontFamily: 'NotoSansKR',
         // fontFamily: 'GmarketSans',
       ),
+      // ✅ [필수 수정] Localizations Delegate 설정 추가
+      // ===============================================================
+      localizationsDelegates: const [
+        // 1. 머티리얼 위젯 (DatePicker, TimePicker) 현지화
+        GlobalMaterialLocalizations.delegate,
+        // 2. 위젯 기본 로케일 처리 (텍스트 방향 등)
+        GlobalWidgetsLocalizations.delegate,
+        // 3. iOS 스타일 위젯 현지화 (선택 사항이지만 포함 권장)
+        GlobalCupertinoLocalizations.delegate,
+      ],
+
+      // ✅ [필수 수정] 지원 로케일 목록 설정
+      supportedLocales: const [
+        Locale('ko', 'KR'), // 한국어 지원
+        Locale('en', 'US'), // 영어 지원 (기본)
+      ],
+
+      // ✅ 기본 로케일을 한국어로 지정 (선택 사항이지만 일관성을 위해 권장)
+      locale: const Locale('ko', 'KR'),
+      // ===============================================================
       home: const OnboardingScreen(),
     );
   }

--- a/albamate_sample/lib/screen/groupPage/notice/sub/approval_request_detail_page.dart
+++ b/albamate_sample/lib/screen/groupPage/notice/sub/approval_request_detail_page.dart
@@ -1,0 +1,462 @@
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:firebase_auth/firebase_auth.dart';
+// 💡 SubstituteRequest 모델 파일 경로 확인
+import 'package:albamate_sample/screen/groupPage/notice/substitute_request.dart';
+import 'dart:convert';
+import 'package:intl/intl.dart';
+
+// ======================================================================
+// App Colors (일관성 유지를 위해 정의)
+// ======================================================================
+
+class AppColors {
+  static const Color appPrimary = Color(0xFF007AFF);
+  static const Color approvalPrimary = Color(0xFF006FFD);
+  static const Color appBackground = Color(0xFFF6F6F8);
+  static const Color appTextPrimary = Color(0xFF1C1C1E);
+  static const Color appTextSecondary = Color(0xFF8E8E93);
+  static const Color white = Colors.white;
+  static const Color rejectColor = Color(0xFFDC2626); // Danger Color
+  static const Color borderGray = Color(0xFFEEEEEE); // Light gray for borders/shadows
+  static const Color sectionTitleColor = Color(0xFF586274);
+}
+
+// ======================================================================
+// ApprovalRequestDetailPage (사장님 상세 승인 페이지)
+// ======================================================================
+
+class ApprovalRequestDetailPage extends StatefulWidget {
+  // 💡 상세 정보를 불러오기 위한 requestId만 받습니다.
+  final String requestId;
+
+  const ApprovalRequestDetailPage({required this.requestId, super.key});
+
+  @override
+  State<ApprovalRequestDetailPage> createState() => _ApprovalRequestDetailPageState();
+}
+
+class _ApprovalRequestDetailPageState extends State<ApprovalRequestDetailPage> {
+  // 💡 데이터를 비동기로 불러오기 위한 Future 변수
+  Future<SubstituteRequest>? _requestDetailFuture;
+  final String _backendBaseUrl = 'https://backend-vgbf.onrender.com/api/substitute/requests';
+
+  @override
+  void initState() {
+    super.initState();
+    _requestDetailFuture = _fetchShiftRequestDetail(widget.requestId);
+  }
+
+  // 1. 요청 ID를 사용하여 상세 정보를 불러오는 함수 (HTTP GET)
+  Future<SubstituteRequest> _fetchShiftRequestDetail(String id) async {
+    final token = await FirebaseAuth.instance.currentUser?.getIdToken();
+
+    final response = await http.get(
+      Uri.parse('$_backendBaseUrl/$id'),
+      headers: {
+        'Authorization': 'Bearer $token',
+        'Content-Type': 'application/json',
+      },
+    );
+
+    if (response.statusCode == 200) {
+      final data = json.decode(utf8.decode(response.bodyBytes))['data'];
+      if (data == null) {
+        throw Exception('요청 상세 정보가 응답 데이터 필드에 없습니다.');
+      }
+      return SubstituteRequest.fromJson(data);
+    } else {
+      final errorBody = json.decode(utf8.decode(response.bodyBytes));
+      throw Exception('요청 상세 정보 로딩 실패: 상태 코드 ${response.statusCode}, 메시지: ${errorBody['message'] ?? '알 수 없는 서버 오류'}');
+    }
+  }
+
+  // 2. 요청 승인/거절 처리 함수 (HTTP PUT)
+Future<void> _handleApproval(String requestId, bool isApproved, String requesterName) async {
+  if (!mounted) return;
+
+  setState(() {
+    _requestDetailFuture = Future.error('Processing...');
+  });
+
+  // 💡 서버 명세에 맞게 final_status 설정
+  final String finalStatus = isApproved ? 'APPROVED' : 'REJECTED';
+  final String actionName = isApproved ? '승인' : '거절';
+
+  try {
+    final token = await FirebaseAuth.instance.currentUser?.getIdToken();
+
+    // 💡 1. URL 경로 변경: /:request_id/manage 로 통일
+    final Uri uri = Uri.parse('$_backendBaseUrl/$requestId/manage');
+
+    // 💡 2. 요청 바디 변경: final_status 필드만 사용
+    final putData = {
+      'final_status': finalStatus,
+    };
+
+    final response = await http.put(
+      uri,
+      headers: {
+        'Authorization': 'Bearer $token',
+        'Content-Type': 'application/json',
+      },
+      body: jsonEncode(putData),
+    );
+
+    // =========================================================
+    // 서버 응답 처리 로직 (이전 버전에서 안정화됨)
+    // =========================================================
+    if (response.statusCode == 200) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('대타 요청이 성공적으로 $actionName 처리되었습니다!')),
+      );
+      Navigator.pop(context, true);
+    } else {
+      String errorMessage;
+      String responseBodyString = utf8.decode(response.bodyBytes);
+
+      try {
+        final responseBody = jsonDecode(responseBodyString);
+        // 서버에서 정의한 에러 메시지를 사용합니다.
+        errorMessage = responseBody['message'] ?? '$actionName 처리 중 알 수 없는 서버 오류가 발생했습니다.';
+      } catch (e) {
+        // JSON 파싱 실패 시 (HTML 응답 등)
+        errorMessage = '서버 응답 오류 (상태: ${response.statusCode}). 서버 로그를 확인해 주세요.';
+      }
+      throw Exception(errorMessage);
+    }
+  } catch (e) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('$actionName 처리 중 오류 발생: ${e.toString().split(':').last.trim()}')),
+    );
+    if (mounted) {
+        setState(() {
+          _requestDetailFuture = _fetchShiftRequestDetail(widget.requestId);
+        });
+    }
+  }
+}
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.appBackground,
+      appBar: AppBar(
+        title: const Text('대타 승인 상세', style: TextStyle(fontWeight: FontWeight.bold, color: AppColors.appTextPrimary)),
+        centerTitle: true,
+        backgroundColor: AppColors.white,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.pop(context),
+        ),
+      ),
+      // 💡 FutureBuilder로 데이터 로딩 처리
+      body: FutureBuilder<SubstituteRequest>(
+        future: _requestDetailFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator(color: AppColors.approvalPrimary));
+          } else if (snapshot.hasError) {
+             // 'Processing' 오류 메시지는 로딩 상태로 처리
+            return Center(child: Text(snapshot.error.toString().contains('Processing') ? '요청 처리 중...' : snapshot.error.toString(), textAlign: TextAlign.center, style: TextStyle(color: AppColors.rejectColor)));
+          } else if (snapshot.hasData) {
+            final request = snapshot.data!;
+            return _buildContent(context, request);
+          }
+          return const Center(child: Text('요청 정보를 찾을 수 없습니다.', style: TextStyle(color: AppColors.appTextSecondary)));
+        },
+      ),
+    );
+  }
+
+  // 3. UI Content Builder
+  Widget _buildContent(BuildContext context, SubstituteRequest request) {
+    // 💡 날짜/시간 포맷팅
+    final DateTime shiftStart = DateTime.parse('${request.shiftDate} ${request.startTime}');
+    final DateTime shiftEnd = DateTime.parse('${request.shiftDate} ${request.endTime}');
+    final String dateDisplay = DateFormat('yyyy년 M월 d일 (E)', 'ko').format(shiftStart);
+    final String timeDisplay = '${DateFormat('HH:mm').format(shiftStart)} ~ ${DateFormat('HH:mm').format(shiftEnd)}';
+
+    return Column(
+        children: [
+          Expanded(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(24.0), // p-6
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // 1. 근무 변경 정보 섹션
+                  _buildSectionTitle('근무 변경 정보'),
+                  _buildProfileSection(request),
+
+                  const SizedBox(height: 24),
+
+                  // 2. 변경될 근무 섹션
+                  _buildSectionTitle('변경될 근무'),
+                  _buildScheduleDetails(dateDisplay, timeDisplay),
+
+                  const SizedBox(height: 24),
+
+                  // 3. 요청 사유 섹션
+                  _buildSectionTitle('요청 사유'),
+                  _buildReasonSection(request.reason),
+                ],
+              ),
+            ),
+          ),
+          // 4. Action Buttons (Sticky Footer)
+          _buildActionButtons(context, request),
+        ],
+      );
+  }
+
+  // 섹션 제목 위젯 (사용자 스타일 유지)
+  Widget _buildSectionTitle(String title) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 8.0),
+      child: Text(
+        title,
+        style: const TextStyle(
+          fontSize: 16,
+          fontWeight: FontWeight.w600,
+          color: AppColors.sectionTitleColor,
+        ),
+      ),
+    );
+  }
+
+  // 프로필 정보 섹션 (요청자 <-> 수락자)
+  Widget _buildProfileSection(SubstituteRequest request) {
+    // 💡 이름에 따른 이니셜 및 색상 설정
+    final String requesterInitial = request.requesterName.isNotEmpty ? request.requesterName[0] : '?';
+    final String substituteInitial = request.substituteName?.isNotEmpty == true ? request.substituteName![0] : '?';
+
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            spreadRadius: 0,
+            blurRadius: 4,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          // 요청자 (From) - 주황색
+          Expanded(
+            child: _buildProfileCard(
+              request.requesterName,
+              '요청자',
+              requesterInitial,
+              Colors.orange,
+            ),
+          ),
+          const SizedBox(width: 8),
+          // 화살표 아이콘
+          const Icon(
+            Icons.arrow_forward,
+            color: AppColors.sectionTitleColor,
+            size: 30,
+          ),
+          const SizedBox(width: 8),
+          // 수락자 (To) - 초록색
+          Expanded(
+            child: _buildProfileCard(
+              request.substituteName ?? '대타 미지정',
+              '대타 지원자',
+              substituteInitial,
+              Colors.green,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // 개별 프로필 카드 (이니셜과 색상 기반으로 변경)
+  Widget _buildProfileCard(String name, String role, String initial, Color baseColor) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        CircleAvatar(
+          radius: 40,
+          backgroundColor: baseColor.withOpacity(0.15),
+          child: Text(
+            initial,
+            style: TextStyle(fontSize: 32, fontWeight: FontWeight.bold, color: baseColor),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          name,
+          style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: AppColors.appTextPrimary),
+        ),
+        Text(
+          role,
+          style: const TextStyle(fontSize: 14, color: AppColors.sectionTitleColor),
+        ),
+      ],
+    );
+  }
+
+  // 변경될 근무 상세 섹션
+  Widget _buildScheduleDetails(String date, String time) {
+    return Container(
+      padding: const EdgeInsets.all(8.0),
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            spreadRadius: 0,
+            blurRadius: 4,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        children: [
+          _buildDetailItem(
+            icon: Icons.calendar_month,
+            label: date,
+            primaryColor: AppColors.approvalPrimary,
+          ),
+          _buildDetailItem(
+            icon: Icons.schedule,
+            label: time,
+            primaryColor: AppColors.approvalPrimary,
+          ),
+        ],
+      ),
+    );
+  }
+
+  // 상세 항목 위젯 (날짜/시간)
+  Widget _buildDetailItem({required IconData icon, required String label, required Color primaryColor}) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 8.0),
+      child: Row(
+        children: [
+          Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: primaryColor.withOpacity(0.1),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Icon(icon, color: primaryColor, size: 24),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Text(
+              label,
+              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500, color: AppColors.appTextPrimary),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // 요청 사유 섹션
+  Widget _buildReasonSection(String reason) {
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            spreadRadius: 0,
+            blurRadius: 4,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Text(
+        reason,
+        style: const TextStyle(
+          fontSize: 15,
+          color: AppColors.appTextPrimary,
+          height: 1.5,
+        ),
+      ),
+    );
+  }
+
+  // 하단 승인/거절 버튼 섹션
+  Widget _buildActionButtons(BuildContext context, SubstituteRequest request) {
+    // 💡 IN_REVIEW 상태일 때만 버튼 활성화
+    final bool isHandled = request.status != 'IN_REVIEW';
+    final String requesterName = request.requesterName;
+
+    return Container(
+      padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + MediaQuery.of(context).padding.bottom),
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        border: Border(
+          top: BorderSide(color: Colors.grey[200]!, width: 1),
+        ),
+      ),
+      child: Row(
+        children: [
+          // 거절 버튼
+          Expanded(
+            child: ElevatedButton(
+              // 💡 거절 로직 호출
+              onPressed: isHandled ? null : () => _handleApproval(request.id, false, requesterName),
+              style: ElevatedButton.styleFrom(
+                foregroundColor: AppColors.rejectColor,
+                backgroundColor: isHandled ? AppColors.borderGray : AppColors.borderGray,
+                elevation: 0,
+                padding: const EdgeInsets.symmetric(vertical: 12),
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+              ),
+              child: Text(
+                '거절하기',
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 16,
+                  color: isHandled ? AppColors.appTextSecondary : AppColors.rejectColor,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          // 승인 버튼
+          Expanded(
+            child: ElevatedButton(
+              // 💡 승인 로직 호출
+              onPressed: isHandled ? null : () => _handleApproval(request.id, true, requesterName),
+              style: ElevatedButton.styleFrom(
+                foregroundColor: AppColors.white,
+                backgroundColor: isHandled ? AppColors.borderGray : AppColors.approvalPrimary,
+                elevation: 0,
+                padding: const EdgeInsets.symmetric(vertical: 12),
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+              ),
+              child: Text(
+                '승인하기',
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 16,
+                  color: isHandled ? AppColors.appTextSecondary : AppColors.white,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/albamate_sample/lib/screen/groupPage/notice/sub/approval_requests_page.dart
+++ b/albamate_sample/lib/screen/groupPage/notice/sub/approval_requests_page.dart
@@ -1,0 +1,443 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:http/http.dart' as http;
+import 'package:firebase_auth/firebase_auth.dart';
+import 'dart:convert';
+// 💡 SubstituteRequest 모델 파일 경로 확인
+import 'package:albamate_sample/screen/groupPage/notice/substitute_request.dart';
+// 💡 상세 페이지 import
+import 'approval_request_detail_page.dart';
+
+// ======================================================================
+// 유틸리티 및 상수
+// ======================================================================
+
+class AppColors {
+  static const Color appBackground = Color(0xFFF6F6F8);
+  static const Color appTextPrimary = Color(0xFF1C1C1E);
+  static const Color approvalPrimary = Color(0xFF006FFD);
+  static const Color white = Colors.white;
+  static const Color dividerColor = Color(0xFFF0F0F0);
+  static const Color appTextSecondary = Color(0xFF8E8E93);
+  static const Color rejectColor = Color(0xFFDC3545); // 거절 버튼 색상
+}
+
+// 승인 대기 상태에 맞춘 색상 및 번역 유틸리티 함수
+Color _getStatusColor(String status) {
+  switch (status) {
+    case 'IN_REVIEW': return AppColors.approvalPrimary;
+    default: return Colors.grey[700]!;
+  }
+}
+
+Color _getStatusBackgroundColor(String status) {
+  switch (status) {
+    case 'IN_REVIEW': return AppColors.approvalPrimary.withOpacity(0.15);
+    default: return Colors.grey[100]!;
+  }
+}
+
+String _translateStatus(String status) {
+  switch (status) {
+    case 'IN_REVIEW': return '승인 대기';
+    default: return '처리 완료';
+  }
+}
+
+// ======================================================================
+
+class ApprovalRequestsPage extends StatefulWidget {
+  final String groupId;
+
+  const ApprovalRequestsPage({required this.groupId, super.key});
+
+  @override
+  State<ApprovalRequestsPage> createState() => _ApprovalRequestsPageState();
+}
+
+class _ApprovalRequestsPageState extends State<ApprovalRequestsPage> {
+  Future<List<SubstituteRequest>>? _requestsFuture;
+  final String _backendUrl = 'https://backend-vgbf.onrender.com/api/substitute/requests';
+
+  // 💡 버튼 중복 클릭 방지 및 로딩 상태 추적을 위한 맵 (requestId: isProcessing)
+  final Map<String, bool> _processingRequests = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _requestsFuture = _fetchApprovalRequests();
+  }
+
+  // 승인 대기 중인 요청 목록을 불러오는 함수 (API 통신)
+  Future<List<SubstituteRequest>> _fetchApprovalRequests() async {
+    final token = await FirebaseAuth.instance.currentUser?.getIdToken();
+
+    // group_id와 status=IN_REVIEW 필터링 쿼리
+    final uri = Uri.parse('$_backendUrl?group_id=${widget.groupId}&status=IN_REVIEW');
+
+    try {
+      final response = await http.get(
+        uri,
+        headers: {
+          'Authorization': 'Bearer $token',
+          'Content-Type': 'application/json',
+        },
+      );
+
+      if (response.statusCode == 200) {
+        final responseBody = jsonDecode(utf8.decode(response.bodyBytes));
+        final List data = responseBody['data'] ?? [];
+
+        return data.map((item) => SubstituteRequest.fromJson(item as Map<String, dynamic>)).toList();
+      } else {
+        final errorBody = jsonDecode(utf8.decode(response.bodyBytes));
+        throw Exception('요청 로딩 실패: 상태 코드 ${response.statusCode}, 메시지: ${errorBody['message'] ?? '알 수 없는 서버 오류'}');
+      }
+    } catch (e) {
+      debugPrint('API 호출 오류: $e');
+      throw Exception('대타 요청 목록을 불러오는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.');
+    }
+  }
+
+  // 요청 목록을 새로고침하는 함수
+  Future<void> _refreshRequests() async {
+    if (mounted) {
+      setState(() {
+        _requestsFuture = _fetchApprovalRequests();
+        _processingRequests.clear(); // 처리 상태 초기화
+      });
+    }
+  }
+
+  // 💡 [통합 로직] 승인/거절 처리를 위한 헬퍼 함수 (상세 페이지와 동일한 API 사용)
+  Future<void> _manageRequest(String requestId, String finalStatus, String actionName) async {
+    if (_processingRequests[requestId] == true) return;
+
+    if (mounted) setState(() { _processingRequests[requestId] = true; });
+
+    try {
+      final token = await FirebaseAuth.instance.currentUser?.getIdToken();
+
+      // 💡 1. URL 경로 변경: /:request_id/manage 로 통일
+      final Uri uri = Uri.parse('$_backendUrl/$requestId/manage');
+
+      // 💡 2. 요청 바디 변경: final_status 필드만 사용
+      final putData = {
+        'final_status': finalStatus, // 'APPROVED' 또는 'REJECTED'
+      };
+
+      final response = await http.put(
+        uri,
+        headers: {
+          'Authorization': 'Bearer $token',
+          'Content-Type': 'application/json',
+        },
+        body: jsonEncode(putData),
+      );
+
+      // =========================================================
+      // 서버 응답 처리 로직
+      // =========================================================
+      if (response.statusCode == 200) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('✅ 대타 요청이 성공적으로 $actionName 처리되었습니다!'), duration: const Duration(seconds: 2)),
+        );
+        // 💡 [목록 핵심 수정]: 처리 후 목록을 새로고침하여 제거
+        _refreshRequests();
+      } else {
+        String errorMessage;
+        String responseBodyString = utf8.decode(response.bodyBytes);
+
+        try {
+          final responseBody = jsonDecode(responseBodyString);
+          errorMessage = responseBody['message'] ?? '$actionName 처리 중 알 수 없는 서버 오류가 발생했습니다.';
+        } catch (e) {
+          errorMessage = '서버 응답 오류 (상태: ${response.statusCode}). 서버 로그를 확인해 주세요.';
+        }
+        throw Exception(errorMessage);
+      }
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('❗️ $actionName 실패: ${e.toString().split(':').last.trim()}'), duration: const Duration(seconds: 3)),
+      );
+    } finally {
+      if (mounted) setState(() { _processingRequests.remove(requestId); });
+    }
+  }
+
+  // 💡 [수정] 대타 요청 승인 처리 함수 (헬퍼 연결)
+  Future<void> _approveRequest(String requestId) async {
+    await _manageRequest(requestId, 'APPROVED', '승인');
+  }
+
+  // 💡 [수정] 대타 요청 거절 처리 함수 (헬퍼 연결)
+  Future<void> _rejectRequest(String requestId) async {
+    await _manageRequest(requestId, 'REJECTED', '거절');
+  }
+
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.appBackground,
+      appBar: AppBar(
+        title: const Text('대타 요청 승인', style: TextStyle(fontWeight: FontWeight.bold, color: AppColors.appTextPrimary)),
+        centerTitle: true,
+        backgroundColor: AppColors.white,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.pop(context),
+        ),
+      ),
+      body: FutureBuilder<List<SubstituteRequest>>(
+        future: _requestsFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator(color: AppColors.approvalPrimary));
+          } else if (snapshot.hasError) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24.0),
+                child: Text(
+                  '데이터 로딩 오류: ${snapshot.error.toString()}',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(color: Colors.red[700]),
+                ),
+              ),
+            );
+          } else if (snapshot.hasData) {
+            final requests = snapshot.data!;
+            final bool isEmpty = requests.isEmpty;
+
+            if (isEmpty) {
+              return _buildEmptyState();
+            }
+
+            // 💡 아래로 당겨 새로고침(Pull-to-refresh) 기능
+            return RefreshIndicator(
+              onRefresh: _refreshRequests,
+              color: AppColors.approvalPrimary,
+              child: ListView.builder(
+                padding: const EdgeInsets.all(16.0),
+                itemCount: requests.length,
+                itemBuilder: (context, index) {
+                  final request = requests[index];
+                  return _buildRequestCard(context, request);
+                },
+              ),
+            );
+          } else {
+             return _buildEmptyState();
+          }
+        },
+      ),
+    );
+  }
+
+  // 요청 카드 위젯
+  Widget _buildRequestCard(BuildContext context, SubstituteRequest request) {
+    final String fromName = request.requesterName;
+    final String toName = request.substituteName ?? '대타 미지정';
+
+    final DateTime shiftStart = DateTime.parse('${request.shiftDate} ${request.startTime}');
+    final DateTime shiftEnd = DateTime.parse('${request.shiftDate} ${request.endTime}');
+
+    final String dateDisplay = DateFormat('yyyy년 M월 d일 (E)', 'ko').format(shiftStart);
+    final String timeDisplay = '${DateFormat('HH:mm').format(shiftStart)} ~ ${DateFormat('HH:mm').format(shiftEnd)}';
+
+    // 현재 요청이 처리 중인지 확인
+    final bool isProcessing = _processingRequests[request.id] == true;
+
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 16),
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.08),
+            spreadRadius: 0,
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        children: [
+          // 1. 요청 정보 섹션 (클릭 영역)
+          GestureDetector(
+            onTap: isProcessing ? null : () {
+              // 💡 상세 페이지로 이동하며 실제 requestId를 전달합니다.
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => ApprovalRequestDetailPage(requestId: request.id),
+                ),
+              ).then((needsRefresh) {
+                // 상세 페이지에서 승인/거절 처리 후 true가 반환되면 목록을 새로고침합니다.
+                if (needsRefresh == true) {
+                  _refreshRequests();
+                }
+              });
+            },
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Row(
+                        children: [
+                          // 요청자 프로필 (주황색)
+                          _buildProfileWithLabel(fromName, fromName.isNotEmpty ? fromName[0] : '?', Colors.orange),
+                          const SizedBox(width: 8),
+                          const Icon(Icons.arrow_right_alt, color: Colors.grey, size: 24),
+                          const SizedBox(width: 8),
+                          // 대타 지원자 프로필 (녹색)
+                          _buildProfileWithLabel(toName, toName.isNotEmpty ? toName[0] : '?', Colors.green),
+                        ],
+                      ),
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                        decoration: BoxDecoration(
+                          color: _getStatusBackgroundColor(request.status),
+                          borderRadius: BorderRadius.circular(20),
+                        ),
+                        child: Text(
+                          _translateStatus(request.status),
+                          style: TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.bold,
+                            color: _getStatusColor(request.status),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+
+                  const Divider(height: 24, thickness: 1, color: AppColors.dividerColor),
+
+                  Padding(
+                    padding: const EdgeInsets.only(left: 4),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          dateDisplay,
+                          style: const TextStyle(color: AppColors.appTextSecondary, fontSize: 15),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          timeDisplay,
+                          style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600, color: AppColors.appTextPrimary),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+
+          // 2. 💡 액션 버튼 섹션
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+            child: Row(
+              children: [
+                // 거절하기 버튼
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: isProcessing ? null : () => _rejectRequest(request.id),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.rejectColor,
+                      foregroundColor: AppColors.white,
+                      minimumSize: const Size(double.infinity, 48),
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                      elevation: 0,
+                    ),
+                    child: isProcessing
+                        ? const SizedBox(width: 24, height: 24, child: CircularProgressIndicator(color: AppColors.white, strokeWidth: 3))
+                        : const Text('거절하기', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                // 승인하기 버튼
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: isProcessing ? null : () => _approveRequest(request.id),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.approvalPrimary,
+                      foregroundColor: AppColors.white,
+                      minimumSize: const Size(double.infinity, 48),
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                      elevation: 0,
+                    ),
+                    child: isProcessing
+                        ? const SizedBox(width: 24, height: 24, child: CircularProgressIndicator(color: AppColors.white, strokeWidth: 3))
+                        : const Text('승인하기', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // 프로필과 이름 위젯 (이니셜 사용)
+  Widget _buildProfileWithLabel(String name, String initial, Color baseColor) {
+    return Column(
+      children: [
+        CircleAvatar(
+          radius: 24,
+          backgroundColor: baseColor.withOpacity(0.15),
+          child: Text(
+            initial,
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: baseColor),
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(name, style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w500, color: AppColors.appTextPrimary)),
+      ],
+    );
+  }
+
+  // 요청이 없을 때 표시되는 위젯
+  Widget _buildEmptyState() {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(48.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Container(
+              width: 80,
+              height: 80,
+              decoration: BoxDecoration(
+                color: Colors.grey[200],
+                shape: BoxShape.circle,
+              ),
+              child: const Icon(Icons.task_alt, size: 40, color: Colors.grey),
+            ),
+            const SizedBox(height: 24),
+            const Text(
+              '모든 요청을 처리했습니다',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600, color: AppColors.appTextPrimary),
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              '승인 대기 중인 대타 요청이 없습니다.',
+              style: TextStyle(color: AppColors.appTextSecondary),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/albamate_sample/lib/screen/groupPage/notice/sub/create_sub_page.dart
+++ b/albamate_sample/lib/screen/groupPage/notice/sub/create_sub_page.dart
@@ -1,173 +1,431 @@
 import 'package:flutter/material.dart';
-import 'package:albamate_sample/screen/groupPage/notice/notice_model.dart';
 import 'package:intl/intl.dart';
 import 'package:http/http.dart' as http;
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart'; 
 import 'dart:convert';
+
+// 💡 요청하신 SubstituteRequest 모델 경로를 사용합니다.
+import 'package:albamate_sample/screen/groupPage/notice/substitute_request.dart'; 
 
 class CreateSubPage extends StatefulWidget {
   final String groupId;
-  final Notice? notice;
-  const CreateSubPage({required this.groupId, this.notice, super.key});
+  // 편집 기능은 구현되지 않았지만 타입 일관성을 위해 SubstituteRequest를 사용
+  final SubstituteRequest? requestToEdit; 
+  
+  const CreateSubPage({required this.groupId, this.requestToEdit, super.key});
 
   @override
   _CreateSubPageState createState() => _CreateSubPageState();
 }
 
 class _CreateSubPageState extends State<CreateSubPage> {
-  final TextEditingController _titleController = TextEditingController();
-  final TextEditingController _contentController = TextEditingController();
-  int _selectedIndex = 0;
+  final _formKey = GlobalKey<FormState>();
+
+  bool _isLoading = false;
+
+  DateTime? _selectedDate;
+  TimeOfDay? _startTime;
+  TimeOfDay? _endTime;
+  final TextEditingController _reasonController = TextEditingController();
+
+  final DateFormat _dateFormat = DateFormat('yyyy년 M월 d일 (E)', 'ko_KR');
+  
+  // UI 상수
+  static const Color primaryColor = Color(0xFF2b6cee);
+  static const Color textLight = Color(0xFF0d121b);
+  static const Color borderLight = Color(0xFFcfd7e7);
+  static const Color placeholderLight = Color(0xFF4c669a);
+  
+  // 백엔드 API URL
+  final String _backendApiUrl = 'https://backend-vgbf.onrender.com/api/substitute/requests';
 
   @override
-  void initState() {
-    super.initState();
-    if (widget.notice != null) {
-      _titleController.text = widget.notice!.title;
-      _contentController.text = widget.notice!.content;
-    }
+  void dispose() {
+    _reasonController.dispose();
+    super.dispose();
   }
 
-  Future<void> _submitPost() async {
-    final user = FirebaseAuth.instance.currentUser;
-    if (user == null) return;
-    final idToken = await user.getIdToken();
+  // --- Date/Time Pickers ---
 
-    final url = widget.notice == null
-        ? Uri.parse('https://backend-vgbf.onrender.com/api/posts')
-        : Uri.parse('https://backend-vgbf.onrender.com/api/posts/${widget.notice!.id}');
-
-    final response = await (widget.notice == null
-        ? http.post(url,
-            headers: {
-              'Authorization': 'Bearer $idToken',
-              'Content-Type': 'application/json'
-            },
-            body: jsonEncode({
-              'groupId': widget.groupId,
-              'title': _titleController.text,
-              'content': _contentController.text,
-              'category': '대타구하기',
-            }))
-        : http.put(url,
-            headers: {
-              'Authorization': 'Bearer $idToken',
-              'Content-Type': 'application/json'
-            },
-            body: jsonEncode({
-              'title': _titleController.text,
-              'content': _contentController.text,
-            })));
-
-    if (response.statusCode == 200 || response.statusCode == 201) {
-      Navigator.pop(context, true);
-    } else {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('오류가 발생했습니다: ${response.body}')),
-      );
-    }
-  }
-
-  Future<void> _deletePost() async {
-    if (widget.notice == null) return;
-    final user = FirebaseAuth.instance.currentUser;
-    final idToken = await user!.getIdToken();
-
-    final response = await http.delete(
-      Uri.parse('https://backend-vgbf.onrender.com/api/posts/${widget.notice!.id}'),
-      headers: {'Authorization': 'Bearer $idToken'},
+  Future<void> _selectDate() async {
+    final DateTime? picked = await showDatePicker(
+      context: context,
+      initialDate: _selectedDate ?? DateTime.now(),
+      firstDate: DateTime.now(),
+      lastDate: DateTime(2028),
+      locale: const Locale('ko', 'KR'),
+      helpText: '대타 요청 날짜 선택',
     );
-
-    if (response.statusCode == 200) {
-      Navigator.pop(context, true);
-    } else {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('삭제 실패: ${response.body}')),
-      );
-    }
-  }
-
-  void _onItemTapped(int index) {
-    if (index == 0) {
-      _deletePost();
-    } else if (index == 1) {
-      _submitPost();
-    } else {
+    if (picked != null && picked != _selectedDate) {
       setState(() {
-        _selectedIndex = index;
+        _selectedDate = picked;
       });
     }
   }
 
+  Future<void> _selectTime(bool isStart) async {
+    final TimeOfDay? picked = await showTimePicker(
+      context: context,
+      initialTime: isStart ? (_startTime ?? TimeOfDay.now()) : (_endTime ?? TimeOfDay.now()),
+      builder: (BuildContext context, Widget? child) {
+        return MediaQuery(
+          data: MediaQuery.of(context).copyWith(alwaysUse24HourFormat: false), 
+          child: child!,
+        );
+      },
+    );
+    if (picked != null) {
+      setState(() {
+        if (isStart) {
+          _startTime = picked;
+        } else {
+          _endTime = picked;
+        }
+      });
+    }
+  }
+
+  // --- Submission Logic with Backend Connection ---
+
+  Future<void> _submitRequest() async {
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+
+    if (_selectedDate == null || _startTime == null || _endTime == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('날짜와 시간을 모두 선택해주세요.')),
+      );
+      return;
+    }
+
+    // 시간 유효성 검사
+    final start = DateTime(
+      _selectedDate!.year, _selectedDate!.month, _selectedDate!.day,
+      _startTime!.hour, _startTime!.minute
+    );
+    final end = DateTime(
+      _selectedDate!.year, _selectedDate!.month, _selectedDate!.day,
+      _endTime!.hour, _endTime!.minute
+    );
+
+    if (end.isBefore(start) || end.isAtSameMomentAs(start)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('종료 시간은 시작 시간보다 늦어야 합니다.')),
+      );
+      return;
+    }
+
+    setState(() => _isLoading = true);
+    
+    try {
+      final user = FirebaseAuth.instance.currentUser;
+      if (user == null) {
+        throw Exception("로그인이 필요합니다.");
+      }
+      
+      final idToken = await user.getIdToken();
+      
+      // 💡 [추가된 로직] Firestore에서 사용자 이름(name) 가져오기
+      final userDoc = await FirebaseFirestore.instance.collection('users').doc(user.uid).get();
+      if (!userDoc.exists || userDoc.data() == null || !userDoc.data()!.containsKey('name')) {
+          throw Exception("Firestore에서 사용자 이름 정보를 찾을 수 없습니다.");
+      }
+      final requesterName = userDoc.data()!['name'] as String;
+      // ----------------------------------------------------
+
+      // 💡 [수정] postData에 'requester_name' 필드 추가
+      final postData = {
+        'group_id': widget.groupId,
+        'shift_date': _selectedDate!.toIso8601String().split('T')[0], // YYYY-MM-DD
+        'start_time': '${_startTime!.hour.toString().padLeft(2, '0')}:${_startTime!.minute.toString().padLeft(2, '0')}:00', // HH:MM:SS
+        'end_time': '${_endTime!.hour.toString().padLeft(2, '0')}:${_endTime!.minute.toString().padLeft(2, '0')}:00',     // HH:MM:SS
+        'reason': _reasonController.text, // 대타 요청 사유
+        'requester_name': requesterName, // <-- 요청자 이름 추가
+      };
+
+      final response = await http.post(
+        Uri.parse(_backendApiUrl), 
+        headers: {
+          'Authorization': 'Bearer $idToken',
+          'Content-Type': 'application/json',
+        },
+        body: jsonEncode(postData),
+      );
+
+      if (response.statusCode == 201) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('대타 요청이 성공적으로 등록되었습니다.')),
+        );
+        // 요청 성공 시 이전 화면으로 돌아가면서 true 반환 (목록 새로고침 유도)
+        if (mounted) Navigator.pop(context, true); 
+      } else {
+        // 서버에서 상세 오류 메시지를 가져옵니다.
+        final responseBody = jsonDecode(utf8.decode(response.bodyBytes));
+        final errorMessage = responseBody['message'] ?? '알 수 없는 서버 오류가 발생했습니다.';
+        
+        throw Exception('요청 등록 실패: $errorMessage (Code: ${response.statusCode})');
+      }
+    } catch (e) {
+      debugPrint('요청 등록 중 오류 발생: $e');
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('요청 등록 중 오류가 발생했습니다: ${e.toString().contains('Exception:') ? e.toString().split('Exception:').last.trim() : '네트워크 또는 인증 오류'}')),
+      );
+    } finally {
+      if (mounted) setState(() => _isLoading = false);
+    }
+  }
+
+  // --- UI Build Methods ---
+
   @override
   Widget build(BuildContext context) {
-    String formattedDate = DateFormat('yyyy/MM/dd').format(DateTime.now());
-
     return Scaffold(
+      backgroundColor: const Color(0xFFf6f6f8), 
       appBar: AppBar(
-        title: Text(
-          '대타 구하기',
+        backgroundColor: const Color(0xFFf6f6f8),
+        leading: const BackButton(color: textLight),
+        title: const Text(
+          '대타 요청 작성',
           style: TextStyle(
+            color: textLight,
             fontSize: 18,
             fontWeight: FontWeight.bold,
-            fontFamily: "Inter",
-            color: Colors.black,
           ),
         ),
-        backgroundColor: Colors.white,
-        elevation: 1,
         centerTitle: true,
-        iconTheme: IconThemeData(color: Colors.black),
+        actions: const [
+          SizedBox(width: 48), 
+        ],
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            TextField(
-              controller: _titleController,
-              decoration: InputDecoration(
-                hintText: "제목을 입력하시오",
-                hintStyle: TextStyle(color: Colors.grey),
-                border: InputBorder.none,
+      
+      body: Form(
+        key: _formKey,
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const SizedBox(height: 12),
+              
+              _buildDateField(
+                title: '날짜',
+                placeholder: '날짜를 선택하세요',
+                value: _selectedDate == null ? '' : _dateFormat.format(_selectedDate!),
+                onTap: _selectDate,
+                icon: Icons.calendar_today,
+                validator: (value) => _selectedDate == null ? '날짜를 선택해주세요.' : null,
               ),
-              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
-            ),
-            SizedBox(height: 8),
-            Text(formattedDate, style: TextStyle(color: Colors.grey)),
-            Divider(thickness: 1),
-            SizedBox(height: 8),
-            Expanded(
-              child: TextField(
-                controller: _contentController,
-                decoration: InputDecoration(
-                  hintText: "내용을 입력하시오",
-                  border: InputBorder.none,
+
+              const SizedBox(height: 12),
+              
+              _buildTimeFields(),
+              
+              const SizedBox(height: 12),
+
+              _buildReasonField(),
+            ],
+          ),
+        ),
+      ),
+      
+      bottomNavigationBar: Container(
+        padding: EdgeInsets.fromLTRB(16, 12, 16, 12 + MediaQuery.of(context).padding.bottom),
+        color: Colors.white, 
+        child: ElevatedButton(
+          onPressed: _isLoading ? null : _submitRequest,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: primaryColor,
+            minimumSize: const Size(double.infinity, 48), 
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+            elevation: 0,
+          ),
+          child: _isLoading 
+              ? const SizedBox(
+                  width: 24, 
+                  height: 24, 
+                  child: CircularProgressIndicator(strokeWidth: 3, valueColor: AlwaysStoppedAnimation<Color>(Colors.white))
+                )
+              : const Text(
+                  '요청 등록',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                    letterSpacing: 0.015,
+                  ),
                 ),
-                maxLines: null,
-                expands: true,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDateField({
+    required String title,
+    required String placeholder,
+    required String value,
+    required VoidCallback onTap,
+    required IconData icon,
+    String? Function(String?)? validator,
+  }) {
+    const inputStyle = TextStyle(
+      color: textLight,
+      fontSize: 16,
+      fontWeight: FontWeight.normal,
+    );
+    const placeholderStyle = TextStyle(
+      color: placeholderLight,
+      fontSize: 16,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (title.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8.0),
+            child: Text(
+              title,
+              style: const TextStyle(
+                color: textLight,
+                fontSize: 16,
+                fontWeight: FontWeight.w500,
               ),
             ),
+          ),
+        GestureDetector(
+          onTap: onTap,
+          child: AbsorbPointer(
+            child: TextFormField(
+              controller: TextEditingController(text: value),
+              decoration: InputDecoration(
+                hintText: placeholder,
+                hintStyle: placeholderStyle,
+                filled: true,
+                fillColor: Colors.white, 
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8.0),
+                  borderSide: const BorderSide(color: borderLight, width: 1),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8.0),
+                  borderSide: const BorderSide(color: borderLight, width: 1),
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8.0),
+                  borderSide: const BorderSide(color: primaryColor, width: 1),
+                ),
+                contentPadding: const EdgeInsets.symmetric(horizontal: 15, vertical: 0),
+                suffixIcon: Padding(
+                  padding: const EdgeInsets.only(right: 16.0),
+                  child: Icon(icon, color: placeholderLight),
+                ),
+                suffixIconConstraints: const BoxConstraints(minHeight: 14, minWidth: 14),
+                constraints: const BoxConstraints(maxHeight: 56), 
+              ),
+              style: inputStyle,
+              validator: validator,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
 
-            IndexedStack(index: _selectedIndex, children: [Container(), Container()]),
-
+  Widget _buildTimeFields() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: 8.0),
+          child: Text(
+            '시간',
+            style: const TextStyle(
+              color: textLight,
+              fontSize: 16,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ),
+        Row(
+          children: [
+            Expanded(
+              child: _buildDateField(
+                title: '',
+                placeholder: '시작 시간', 
+                value: _startTime?.format(context) ?? '',
+                onTap: () => _selectTime(true),
+                icon: Icons.schedule,
+                validator: (value) => _startTime == null ? '시작 시간을 선택해주세요.' : null,
+              ),
+            ),
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 8.0),
+              child: Text('~', style: TextStyle(color: textLight, fontSize: 18)),
+            ),
+            Expanded(
+              child: _buildDateField(
+                title: '',
+                placeholder: '종료 시간', 
+                value: _endTime?.format(context) ?? '',
+                onTap: () => _selectTime(false),
+                icon: Icons.schedule,
+                validator: (value) => _endTime == null ? '종료 시간을 선택해주세요.' : null,
+              ),
+            ),
           ],
         ),
-      ),
-      bottomNavigationBar: SizedBox(
-        height: 88,
-        child: BottomNavigationBar(
-          backgroundColor: Colors.white,
-          items: [
-            BottomNavigationBarItem(icon: Icon(Icons.delete), label: "삭제하기"),
-            BottomNavigationBarItem(icon: Icon(Icons.upload), label: "등록하기"),
-          ],
-          currentIndex: _selectedIndex,
-          selectedItemColor: Colors.grey,
-          unselectedItemColor: Colors.grey,
-          onTap: _onItemTapped,
+      ],
+    );
+  }
+
+  Widget _buildReasonField() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: 8.0),
+          child: Text(
+            '사유',
+            style: const TextStyle(
+              color: textLight,
+              fontSize: 16,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
         ),
-      ),
+        TextFormField(
+          controller: _reasonController,
+          maxLines: 6, 
+          decoration: InputDecoration(
+            hintText: '대타를 구하는 이유를 자세히 적어주세요. (예: 급한 가족 행사)',
+            hintStyle: const TextStyle(color: placeholderLight, fontSize: 16),
+            filled: true,
+            fillColor: Colors.white, 
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8.0),
+              borderSide: const BorderSide(color: borderLight, width: 1),
+            ),
+            enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8.0),
+              borderSide: const BorderSide(color: borderLight, width: 1),
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8.0),
+              borderSide: const BorderSide(color: primaryColor, width: 1),
+            ),
+            contentPadding: const EdgeInsets.all(15.0),
+          ),
+          style: const TextStyle(color: textLight, fontSize: 16),
+          validator: (value) {
+            if (value == null || value.isEmpty) {
+              return '사유를 입력해주세요.';
+            }
+            return null;
+          },
+        ),
+      ],
     );
   }
 }

--- a/albamate_sample/lib/screen/groupPage/notice/sub/detail_sub_page.dart
+++ b/albamate_sample/lib/screen/groupPage/notice/sub/detail_sub_page.dart
@@ -1,295 +1,469 @@
+//dart:Substitute Request Detail Screen (Final Corrected Code - Fix Claimed State):lib/screen/groupPage/notice/detail_sub_page.dart
 import 'package:flutter/material.dart';
-import 'package:albamate_sample/screen/groupPage/notice/notice_model.dart';
-import 'package:albamate_sample/component/groupHome_navigation.dart';
+import 'package:albamate_sample/screen/groupPage/notice/substitute_request.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:http/http.dart' as http;
 import 'package:intl/intl.dart';
 import 'dart:convert';
 
-class Comment {
-  final String id;
-  final String userUid;
-  final String content;
-  final String userName;
+// ======================================================================
+// 1. App Colors & Constants
+// ======================================================================
 
-  Comment({
-    required this.id,
-    required this.userUid,
-    required this.content,
-    required this.userName,
-  });
+class AppColors {
+  static const Color appPrimary = Color(0xFF007AFF); // primary
+  static const Color appBackground = Color(0xFFF2F2F7);
+  static const Color appTextPrimary = Color(0xFF1C1C1E);
+  static const Color appTextSecondary = Color(0xFF8E8E93);
+  static const Color borderGray = Color(0xFFE5E5EA);
+  static const Color white = Colors.white;
 }
 
-class DetailSubPage extends StatefulWidget {
-  final Notice notice;
+// ======================================================================
+// 2. Helper Class for UI (SubstituteRequest의 데이터를 UI 친화적으로 변환)
+// ======================================================================
 
-  const DetailSubPage({super.key, required this.notice});
+class SubstituteRequestDisplay {
+  final SubstituteRequest request;
+  final DateTime shiftStart;
+  final DateTime shiftEnd;
+  final bool isAcceptable;
+
+  SubstituteRequestDisplay(this.request)
+      : shiftStart = _parseDateTime(request.shiftDate, request.startTime),
+        shiftEnd = _parseDateTime(request.shiftDate, request.endTime),
+        // PENDING 또는 IN_REVIEW 상태일 때만 수락 가능하다고 간주
+        isAcceptable = request.status == 'PENDING' || request.status == 'IN_REVIEW';
+
+  static DateTime _parseDateTime(String date, String time) {
+    try {
+      return DateTime.parse('$date $time');
+    } catch (e) {
+      return DateTime.now();
+    }
+  }
+}
+
+// ======================================================================
+// 3. DetailSubPage (메인 위젯)
+// ======================================================================
+
+class DetailSubPage extends StatefulWidget {
+  final String requestId;
+  final String userRole;
+
+  const DetailSubPage({required this.requestId, required this.userRole, super.key});
 
   @override
   State<DetailSubPage> createState() => _DetailSubPageState();
 }
 
 class _DetailSubPageState extends State<DetailSubPage> {
-  final TextEditingController _commentController = TextEditingController();
-  List<Comment> comments = [];
-  String currentUid = '';
+  late Future<SubstituteRequest> _requestDetailFuture;
+
+  final String _backendBaseUrl = 'https://backend-vgbf.onrender.com/api/substitute/requests';
+  String? _currentUserName;
+  String? _currentUserId;
 
   @override
   void initState() {
     super.initState();
-    _loadCurrentUidAndComments();
+    _fetchUserData();
+    _requestDetailFuture = _fetchShiftRequestDetail(widget.requestId);
   }
 
-  Future<void> _loadCurrentUidAndComments() async {
+  Future<void> _fetchUserData() async {
     final user = FirebaseAuth.instance.currentUser;
     if (user != null) {
-      currentUid = user.uid;
-      await _fetchComments();
+      _currentUserId = user.uid;
+      final userDoc = await FirebaseFirestore.instance.collection('users').doc(user.uid).get();
+      if (userDoc.exists && mounted) {
+        setState(() {
+          _currentUserName = userDoc.data()?['name'];
+        });
+      }
     }
   }
 
-  Future<void> _fetchComments() async {
-    final user = FirebaseAuth.instance.currentUser;
-    if (user == null) return;
-
-    final idToken = await user.getIdToken();
+  Future<SubstituteRequest> _fetchShiftRequestDetail(String id) async {
+    final token = await FirebaseAuth.instance.currentUser?.getIdToken();
 
     final response = await http.get(
-      Uri.parse(
-        'https://backend-vgbf.onrender.com/api/posts/${widget.notice.id}/comments',
-      ),
-      headers: {'Authorization': 'Bearer $idToken'},
-    );
-
-    if (response.statusCode == 200) {
-      final List data = jsonDecode(response.body)['data'];
-      final List<Comment> loaded = [];
-
-      for (var c in data) {
-        final uid = c['user_uid'];
-        final name = await _getUserName(uid);
-        loaded.add(
-          Comment(
-            id: c['id'].toString(),
-            userUid: uid,
-            content: c['content'],
-            userName: name,
-          ),
-        );
-      }
-
-      setState(() {
-        comments = loaded;
-      });
-    }
-  }
-
-  Future<String> _getUserName(String uid) async {
-    try {
-      final doc =
-          await FirebaseFirestore.instance.collection('users').doc(uid).get();
-      if (doc.exists && doc.data() != null) {
-        return doc.data()!['name'] ?? '익명';
-      }
-    } catch (_) {}
-    return '익명';
-  }
-
-  Future<void> _addComment() async {
-    final user = FirebaseAuth.instance.currentUser;
-    if (user == null) return;
-
-    final idToken = await user.getIdToken();
-    final content = _commentController.text.trim();
-
-    if (content.isEmpty) return;
-
-    final response = await http.post(
-      Uri.parse(
-        'https://backend-vgbf.onrender.com/api/posts/${widget.notice.id}/comments',
-      ),
+      Uri.parse('$_backendBaseUrl/$id'),
       headers: {
-        'Authorization': 'Bearer $idToken',
+        'Authorization': 'Bearer $token',
         'Content-Type': 'application/json',
       },
-      body: jsonEncode({
-        'postId': widget.notice.id, // ✅ 꼭 포함
-        'content': content,
-      }),
-    );
-
-    if (response.statusCode == 201) {
-      _commentController.clear();
-      await _fetchComments();
-    } else {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('댓글 등록에 실패했어요')));
-    }
-  }
-
-  Future<void> _deleteComment(String commentId) async {
-    final user = FirebaseAuth.instance.currentUser;
-    if (user == null) return;
-
-    final idToken = await user.getIdToken();
-
-    final response = await http.delete(
-      Uri.parse(
-        'https://backend-vgbf.onrender.com/api/posts/${widget.notice.id}/comments/$commentId',
-      ),
-      headers: {'Authorization': 'Bearer $idToken'},
     );
 
     if (response.statusCode == 200) {
-      await _fetchComments();
+      final data = json.decode(utf8.decode(response.bodyBytes))['data'];
+      if (data == null) {
+        throw Exception('요청 상세 정보가 응답 데이터 필드에 없습니다.');
+      }
+      return SubstituteRequest.fromJson(data);
     } else {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('댓글 삭제에 실패했어요')));
+      final errorBody = json.decode(utf8.decode(response.bodyBytes));
+      throw Exception('요청 상세 정보 로딩 실패: 상태 코드 ${response.statusCode}, 메시지: ${errorBody['message'] ?? '알 수 없는 서버 오류'}');
     }
   }
+
+  void _acceptShift(String requestId) async {
+    if (_currentUserName == null || _currentUserId == null) {
+       ScaffoldMessenger.of(context).showSnackBar(
+         const SnackBar(content: Text('사용자 정보를 가져오는 중입니다. 잠시 후 다시 시도해주세요.'), duration: Duration(seconds: 2)),
+       );
+      return;
+    }
+
+    if (mounted) setState(() { _requestDetailFuture = Future.error('Loading...'); });
+
+    try {
+      final token = await FirebaseAuth.instance.currentUser?.getIdToken();
+
+      final putData = {
+        'substitute_id': _currentUserId,
+        'substitute_name': _currentUserName,
+      };
+
+      final response = await http.put(
+        Uri.parse('$_backendBaseUrl/$requestId/accept'),
+        headers: {
+          'Authorization': 'Bearer $token',
+          'Content-Type': 'application/json',
+        },
+        body: jsonEncode(putData),
+      );
+
+      if (response.statusCode == 200) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('${_currentUserName}님의 대타 수락 요청을 보냈습니다!'), duration: const Duration(seconds: 2)),
+        );
+        _requestDetailFuture = _fetchShiftRequestDetail(widget.requestId);
+      } else {
+        final responseBody = jsonDecode(utf8.decode(response.bodyBytes));
+        final errorMessage = responseBody['message'] ?? '수락 중 알 수 없는 서버 오류가 발생했습니다.';
+        throw Exception(errorMessage);
+      }
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('수락 요청 중 오류 발생: ${e.toString().split(':').last.trim()}'), duration: const Duration(seconds: 3)),
+      );
+      _requestDetailFuture = _fetchShiftRequestDetail(widget.requestId);
+    } finally {
+       if (mounted) setState(() {});
+    }
+  }
+
 
   @override
   Widget build(BuildContext context) {
-    final String createdDate = DateFormat(
-      'yyyy-MM-dd',
-    ).format(DateTime.parse(widget.notice.createdAt).toLocal());
+    final bool isBoss = widget.userRole == '사장님';
 
     return Scaffold(
+      backgroundColor: AppColors.appBackground,
       appBar: AppBar(
-        title: Text(
-          '대타 구하기',
+        backgroundColor: AppColors.appBackground,
+        elevation: 0,
+        centerTitle: true,
+        title: const Text(
+          '대타 요청 상세',
           style: TextStyle(
+            color: AppColors.appTextPrimary,
             fontSize: 18,
             fontWeight: FontWeight.bold,
-            fontFamily: "Inter",
-            color: Colors.black,
           ),
         ),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: AppColors.appTextPrimary, size: 30),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        actions: const [SizedBox(width: 48)],
+      ),
 
-        centerTitle: true,
-        backgroundColor: Colors.white,
-        elevation: 1,
-        iconTheme: IconThemeData(color: Colors.black),
-        actions: [
-          //home 버튼 누르면 groupHome으로
-          IconButton(
-            icon: Icon(Icons.home),
-            onPressed: () {
-              Navigator.pushAndRemoveUntil(
-                context,
-                MaterialPageRoute(
-                  builder:
-                      (context) => GroupNav(
-                        groupId: widget.notice.groupId,
-                        // TODO: ⚠️ 현재 userRole 임시 사용 중 (백엔드 ownerId 연동 시 제거 예정)
-                        userRole: '',
-                        initialIndex: 2,
-                      ),
-                ),
-                (Route<dynamic> route) => false,
-              );
-            },
+      body: FutureBuilder<SubstituteRequest>(
+        future: _requestDetailFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator(color: AppColors.appPrimary));
+          } else if (snapshot.hasError) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Text('데이터를 불러오지 못했습니다: ${snapshot.error}', textAlign: TextAlign.center, style: const TextStyle(color: AppColors.appTextSecondary)),
+              ),
+            );
+          } else if (snapshot.hasData) {
+            final rawRequest = snapshot.data!;
+            final displayRequest = SubstituteRequestDisplay(rawRequest);
+
+            return _buildContent(context, displayRequest);
+          } else {
+            return const Center(child: Text('요청 정보를 찾을 수 없습니다.', style: TextStyle(color: AppColors.appTextSecondary)));
+          }
+        },
+      ),
+
+      bottomNavigationBar: isBoss ? null : _buildBottomCtaDynamic(),
+    );
+  }
+
+  // --- UI 빌더 함수 ---
+
+  Widget _buildContent(BuildContext context, SubstituteRequestDisplay request) {
+    final double bottomPadding = widget.userRole == '사장님' ? 16 : 120;
+
+    return SingleChildScrollView(
+        padding: EdgeInsets.only(bottom: bottomPadding),
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _buildRequesterInfoCard(request),
+              const SizedBox(height: 16),
+              _buildShiftDetailsCard(request),
+              const SizedBox(height: 16),
+              _buildReasonCard(request),
+            ],
+          ),
+        ),
+      );
+  }
+
+  Widget _buildRequesterInfoCard(SubstituteRequestDisplay request) {
+    String statusText;
+    Color statusBgColor;
+    Color statusTextColor;
+
+    final status = request.request.status;
+    final substituteName = request.request.substituteName;
+
+    // 💡 [수정]: 상태별 표시 텍스트와 색상을 명확하게 분리
+    if (status == 'APPROVED') {
+      // 최종 승인 완료
+      statusText = substituteName != null ? '$substituteName 수락 완료' : '승인 완료';
+      statusBgColor = Colors.green[100]!;
+      statusTextColor = Colors.green[700]!;
+    } else if (status == 'IN_REVIEW') {
+      // 대타가 수락했지만 사장님 승인 대기 중인 상태
+      statusText = substituteName != null ? '$substituteName 승인 대기' : '승인 대기';
+      statusBgColor = AppColors.appPrimary.withOpacity(0.15);
+      statusTextColor = AppColors.appPrimary;
+    } else if (status == 'PENDING') {
+      // 아직 아무도 수락하지 않은 상태
+      statusText = '대타 찾는 중';
+      statusBgColor = Colors.grey[100]!;
+      statusTextColor = AppColors.appTextSecondary;
+    } else if (status == 'REJECTED') {
+      // 거절됨
+      statusText = '거절됨';
+      statusBgColor = Colors.red[100]!;
+      statusTextColor = Colors.red[600]!;
+    }
+    else {
+      // 기타 마감/취소 등
+      statusText = '마감/취소';
+      statusBgColor = AppColors.appTextSecondary.withOpacity(0.1);
+      statusTextColor = AppColors.appTextSecondary;
+    }
+
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      decoration: _cardDecoration(),
+      child: Row(
+        children: [
+          CircleAvatar(
+            radius: 24,
+            backgroundColor: AppColors.appPrimary.withOpacity(0.1),
+            child: const Icon(
+              Icons.person,
+              color: AppColors.appPrimary,
+              size: 30,
+            ),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(request.request.requesterName, style: const TextStyle(color: AppColors.appTextPrimary, fontSize: 16, fontWeight: FontWeight.bold), overflow: TextOverflow.ellipsis),
+                const Text('요청자 (알바)', style: TextStyle(color: AppColors.appTextSecondary, fontSize: 14)),
+              ],
+            ),
+          ),
+          Container(
+            height: 32,
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            decoration: BoxDecoration(color: statusBgColor, borderRadius: BorderRadius.circular(8.0)),
+            alignment: Alignment.center,
+            child: Text(
+              statusText,
+              style: TextStyle(color: statusTextColor, fontSize: 14, fontWeight: FontWeight.bold),
+            ),
           ),
         ],
       ),
-      body: Column(
+    );
+  }
+
+  Widget _buildShiftDetailsCard(SubstituteRequestDisplay request) {
+    final DateFormat dateFormatter = DateFormat('yyyy년 M월 d일 (E)', 'ko');
+    final String dateDisplay = dateFormatter.format(request.shiftStart);
+
+    final int durationInMinutes = request.shiftEnd.difference(request.shiftStart).inMinutes;
+    final double durationInHours = durationInMinutes / 60.0;
+
+    final String timeDisplay = '${DateFormat('HH:mm').format(request.shiftStart)} ~ ${DateFormat('HH:mm').format(request.shiftEnd)}';
+    final String durationDisplay = '${durationInHours.toStringAsFixed(durationInHours.truncateToDouble() == durationInHours ? 0 : 1)}시간';
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16.0),
+      decoration: _cardDecoration(),
+      child: Column(
         children: [
-          Expanded( // ✅ 전체 스크롤 가능 영역
-            child: SingleChildScrollView(
-              child: Column(
-                children: [
-                  // 공지 카드
-                  Container(
-                    padding: EdgeInsets.all(16),
-                    width: double.infinity,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
-                          children: [
-                            CircleAvatar(backgroundColor: Colors.grey[300], radius: 20),
-                            SizedBox(width: 8),
-                            Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  widget.notice.title,
-                                  style: TextStyle(
-                                    fontWeight: FontWeight.bold,
-                                    fontSize: 16,
-                                  ),
-                                ),
-                                Text(
-                                  createdDate,
-                                  style: TextStyle(color: Colors.grey, fontSize: 12),
-                                ),
-                              ],
-                            ),
-                            Spacer(),
-                          ],
-                        ),
-                        SizedBox(height: 12),
-                        Text(widget.notice.content),
-                      ],
-                    ),
-                  ),
+          _buildDetailRow('근무 날짜', dateDisplay, needsDivider: false),
+          _buildDetailRow('근무 시간', '$timeDisplay ($durationDisplay)', needsDivider: true),
+        ],
+      ),
+    );
+  }
 
-                  // 댓글 목록
-                  if (comments.isEmpty)
-                    Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: Center(child: Text('댓글이 없습니다.')),
-                    )
-                  else
-                    ListView.builder(
-                      shrinkWrap: true,
-                      physics: NeverScrollableScrollPhysics(),
-                      itemCount: comments.length,
-                      itemBuilder: (context, index) {
-                        final comment = comments[index];
-                        return ListTile(
-                          leading: CircleAvatar(
-                            backgroundColor: Colors.grey[300],
-                          ),
-                          title: Text(comment.userName),
-                          subtitle: Text(comment.content),
-                          trailing: comment.userUid == currentUid
-                              ? IconButton(
-                            icon: Icon(Icons.delete, color: Colors.red),
-                            onPressed: () => _deleteComment(comment.id),
-                          )
-                              : null,
-                        );
-                      },
-                    ),
-                ],
+  Widget _buildDetailRow(String label, String value, {required bool needsDivider}) {
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 16.0),
+      decoration: BoxDecoration(
+        border: needsDivider ? const Border(top: BorderSide(color: AppColors.borderGray, width: 1)) : null,
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(label, style: const TextStyle(color: AppColors.appTextSecondary, fontSize: 14, fontWeight: FontWeight.normal)),
+          Text(value, style: const TextStyle(color: AppColors.appTextPrimary, fontSize: 14, fontWeight: FontWeight.w500)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildReasonCard(SubstituteRequestDisplay request) {
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      decoration: _cardDecoration(),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('요청 사유', style: const TextStyle(color: AppColors.appTextPrimary, fontSize: 16, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 12),
+          Text(request.request.reason, style: const TextStyle(color: AppColors.appTextPrimary, fontSize: 14, height: 1.5)),
+        ],
+      ),
+    );
+  }
+
+  BoxDecoration _cardDecoration() {
+    return BoxDecoration(
+      color: AppColors.white,
+      borderRadius: BorderRadius.circular(16.0),
+      boxShadow: [
+        BoxShadow(color: Colors.black.withOpacity(0.05), blurRadius: 4, offset: const Offset(0, 2)),
+      ],
+    );
+  }
+
+  // 4. CTA 버튼 로직 (비활성화 로직 포함)
+  Widget _buildBottomCtaDynamic() {
+    return FutureBuilder<SubstituteRequest>(
+      future: _requestDetailFuture,
+      builder: (context, snapshot) {
+        bool isLoading = snapshot.connectionState == ConnectionState.waiting;
+        final bool isDataAvailable = snapshot.hasData;
+
+        String buttonText = '대타 수락하기';
+        String? message;
+        VoidCallback? onPressed;
+        bool isButtonEnabled = false;
+
+        if (isLoading || _currentUserName == null) {
+          message = '정보를 불러오는 중...';
+        } else if (!isDataAvailable || snapshot.hasError) {
+          message = '요청 정보를 가져올 수 없습니다.';
+        } else {
+          final rawRequest = snapshot.data!;
+          final displayRequest = SubstituteRequestDisplay(rawRequest);
+
+          final bool isOwner = rawRequest.requesterName == _currentUserName;
+          final bool isClaimed = rawRequest.substituteName != null;
+
+          if (isOwner) {
+            // Case 1: 요청자 본인 (비활성화)
+            message = '본인이 요청한 근무는 수락할 수 없습니다.';
+          } else if (rawRequest.status == 'APPROVED' || rawRequest.status == 'REJECTED') {
+            // Case 2: 상태가 APPROVED/REJECTED 등으로 최종 확정된 경우 (비활성화)
+            message = rawRequest.status == 'APPROVED' ?
+                      '${rawRequest.substituteName}님이 최종 수락했습니다.' :
+                      '이미 거절되어 마감된 요청입니다.';
+          } else if (rawRequest.status == 'IN_REVIEW') {
+             // 💡 [수정]: Case 3: IN_REVIEW 상태일 때 (누군가 수락한 상태)
+            message = '${rawRequest.substituteName}님이 이 근무를 수락 대기 중입니다. (사장님 승인 필요)';
+          } else if (rawRequest.status == 'PENDING' && !isClaimed) {
+            // Case 4: 상태가 PENDING 이고 아직 아무도 수락하지 않은 경우 (활성화)
+            message = null;
+            onPressed = () => _acceptShift(rawRequest.id);
+            isButtonEnabled = true;
+          } else {
+            // 기타 상태 (예: PENDING인데 substituteName이 잘못 남아있는 경우 등)
+             message = '현재 상태에서는 대타 수락이 불가능합니다.';
+          }
+        }
+
+        final finalOnPressed = isButtonEnabled ? onPressed : null;
+
+        return _buildCtaButton(
+          context,
+          text: buttonText,
+          onPressed: finalOnPressed,
+          message: message,
+        );
+      },
+    );
+  }
+
+  Widget _buildCtaButton(BuildContext context, {required String text, VoidCallback? onPressed, String? message}) {
+    final bool isEnabled = onPressed != null;
+
+    return Container(
+      padding: EdgeInsets.fromLTRB(16, 12, 16, 12 + MediaQuery.of(context).padding.bottom),
+      decoration: BoxDecoration(
+        color: AppColors.white.withOpacity(0.95),
+        border: const Border(top: BorderSide(color: AppColors.borderGray, width: 0.5)),
+        boxShadow: [BoxShadow(color: Colors.black.withOpacity(0.05), blurRadius: 10, offset: const Offset(0, -5))],
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (message != null)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8.0),
+              child: Text(message, textAlign: TextAlign.center, style: const TextStyle(color: AppColors.appTextSecondary, fontSize: 12)),
+            ),
+          ElevatedButton(
+            onPressed: onPressed, // null이면 클릭 불가
+            style: ElevatedButton.styleFrom(
+              // 비활성화 시 색상 변경
+              backgroundColor: isEnabled ? AppColors.appPrimary : AppColors.borderGray,
+              minimumSize: const Size(double.infinity, 48),
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+              elevation: 0,
+            ),
+            child: Text(
+              text,
+              style: TextStyle(
+                // 비활성화 시 텍스트 색상 변경
+                color: isEnabled ? AppColors.white : AppColors.appTextSecondary,
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
               ),
-            ),
-          ),
-
-          // ✅ 댓글 작성창은 고정
-          Container(
-            padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-            decoration: BoxDecoration(
-              border: Border(top: BorderSide(color: Colors.grey.shade300)),
-              color: Colors.grey[100],
-            ),
-            child: Row(
-              children: [
-                Expanded(
-                  child: TextField(
-                    controller: _commentController,
-                    decoration: InputDecoration(
-                      hintText: '댓글을 작성하세요.',
-                      border: InputBorder.none,
-                    ),
-                  ),
-                ),
-                ElevatedButton(onPressed: _addComment, child: Text('등록')),
-              ],
             ),
           ),
         ],

--- a/albamate_sample/lib/screen/groupPage/notice/sub/screen_sub_page.dart
+++ b/albamate_sample/lib/screen/groupPage/notice/sub/screen_sub_page.dart
@@ -1,12 +1,48 @@
 import 'package:flutter/material.dart';
-import 'create_sub_page.dart';
+import 'package:intl/intl.dart';
+import 'package:albamate_sample/screen/groupPage/notice/substitute_request.dart';
 import 'detail_sub_page.dart';
-import 'package:albamate_sample/screen/groupPage/notice/notice_model.dart';
+import 'create_sub_page.dart';
+// 💡 [경로 수정]: 이 import 경로를 'approval_requests_page.dart' 파일의 실제 위치에 맞게 수정하세요!
+import 'approval_requests_page.dart';
 import 'package:http/http.dart' as http;
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:intl/intl.dart';
 import 'dart:convert';
+
+// ======================================================================
+// 💡 백엔드 상태 문자열 기반 색상 및 번역 유틸리티 함수
+Color _getStatusColor(String status) {
+  switch (status) {
+    case 'APPROVED': return Colors.green[700]!;
+    case 'IN_REVIEW': return const Color(0xFF006FFD);
+    case 'PENDING': return Colors.grey[600]!;
+    case 'REJECTED': return Colors.red[600]!;
+    default: return Colors.grey;
+  }
+}
+
+Color _getStatusBackgroundColor(String status) {
+  switch (status) {
+    case 'APPROVED': return Colors.green[100]!;
+    case 'IN_REVIEW': return const Color(0xFF006FFD).withOpacity(0.15);
+    case 'PENDING': return Colors.grey[100]!;
+    case 'REJECTED': return Colors.red[100]!;
+    default: return Colors.grey[100]!;
+  }
+}
+
+String _translateStatus(String status) {
+  switch (status) {
+    case 'APPROVED': return '승인 완료';
+    case 'IN_REVIEW': return '승인 대기';
+    case 'PENDING': return '대타 구하는 중';
+    case 'REJECTED': return '거절됨';
+    default: return '알 수 없음';
+  }
+}
+
+// ======================================================================
 
 class ScreenSubPage extends StatefulWidget {
   final String groupId;
@@ -18,193 +54,356 @@ class ScreenSubPage extends StatefulWidget {
 }
 
 class _ScreenSubPageState extends State<ScreenSubPage> {
-  List<Notice> notices = [];
+  List<SubstituteRequest> requests = [];
   String? userRole;
   String? userUid;
+  String? userName;
   bool _isLoading = false;
+  final String _backendUrl = 'https://backend-vgbf.onrender.com/api/substitute/requests';
 
   @override
   void initState() {
     super.initState();
-    _fetchUserRoleAndNotices();
+    userUid = FirebaseAuth.instance.currentUser?.uid;
+    _fetchUserRoleAndRequests();
   }
 
-  Future<void> _fetchUserRoleAndNotices() async {
+  // 💡 [핵심 수정 함수]
+  Future<void> _fetchUserRoleAndRequests() async {
     if (!mounted) return;
     setState(() => _isLoading = true);
 
     try {
       final user = FirebaseAuth.instance.currentUser;
-      if (user == null) return;
-      userUid = user.uid;
+      String currentRole = '알바생'; // 💡 기본값을 '알바생'으로 설정
+      String? fetchedUserName;
 
-      final userDoc = await FirebaseFirestore.instance.collection('users').doc(user.uid).get();
-      if (userDoc.exists && mounted) {
-        setState(() => userRole = userDoc['role']);
+      if (user != null) {
+        final userDoc = await FirebaseFirestore.instance.collection('users').doc(user.uid).get();
+        if (userDoc.exists) {
+            String fetchedRole = userDoc.data()?['role'] ?? '알바생';
+            if (fetchedRole == '사장님') {
+                currentRole = '사장님';
+            } else {
+                // "사장님"이 아닌 모든 값은 안전하게 '알바생'으로 처리
+                currentRole = '알바생';
+            }
+            fetchedUserName = userDoc.data()?['name'];
+        }
       }
 
-      final idToken = await user.getIdToken();
+      // 상태 업데이트
+      if(mounted) {
+        setState(() {
+          userRole = currentRole;
+          userName = fetchedUserName;
+        });
+      }
+
+      // 💡 [핵심 디버깅]: 현재 역할 확인
+      debugPrint('================================================');
+      debugPrint('현재 사용자 역할: $currentRole');
+
+      // 💡 [핵심 필터링]: 알바생 역할일 때만 PENDING 상태 필터를 추가
+      String requestUrl = '$_backendUrl?group_id=${widget.groupId}';
+      if (currentRole != '사장님') {
+        // 알바생인 경우, PENDING 상태의 게시글만 요청
+        requestUrl += '&status=PENDING';
+      }
+
+      // 💡 [핵심 디버깅]: 최종 API 요청 URL 확인
+      debugPrint('최종 API Request URL: $requestUrl');
+      debugPrint('================================================');
+
+      final token = await user?.getIdToken();
+
       final response = await http.get(
-        Uri.parse('https://backend-vgbf.onrender.com/api/posts?groupId=${widget.groupId}&category=대타구하기'),
-        headers: {'Authorization': 'Bearer $idToken'},
+        Uri.parse(requestUrl),
+        headers: {
+          'Authorization': 'Bearer $token',
+          'Content-Type': 'application/json',
+        },
       );
 
       if (response.statusCode == 200 && mounted) {
-        final data = jsonDecode(response.body)['data'] as List;
+        final Map<String, dynamic> responseBody = jsonDecode(utf8.decode(response.bodyBytes));
+        final data = responseBody['data'] as List;
+
+        final List<SubstituteRequest> fetchedRequests = [];
+        for (var item in data) {
+          try {
+            final request = SubstituteRequest.fromJson(item);
+            fetchedRequests.add(request);
+          } catch (e) {
+            debugPrint('경고: JSON 파싱 오류 또는 ID 누락으로 항목 제외: $e');
+          }
+        }
+
         setState(() {
-          notices = data.map((e) => Notice.fromJson(e)).toList();
+          requests = fetchedRequests;
           _isLoading = false;
         });
       } else {
-        print('대타 공지 불러오기 실패: ${response.statusCode} - ${response.body}');
-        if (mounted) setState(() => _isLoading = false);
+        debugPrint('API 호출 실패: ${response.statusCode}, ${response.body}');
+        if (mounted) {
+           setState(() {
+             requests = [];
+             _isLoading = false;
+           });
+        }
       }
     } catch (e) {
-      print('대타 공지 불러오기 오류: $e');
-      if (mounted) setState(() => _isLoading = false);
+      debugPrint('데이터 불러오기 오류: $e');
+      if (mounted) {
+        setState(() {
+          requests = [];
+          _isLoading = false;
+        });
+      }
     }
   }
 
-  Future<void> _deleteNotice(String postId) async {
-    if (!mounted) return;
-
+  Future<void> _deleteRequest(String requestId, String requesterName) async {
     try {
-      final user = FirebaseAuth.instance.currentUser;
-      if (user == null) return;
-      final idToken = await user.getIdToken();
+      final token = await FirebaseAuth.instance.currentUser?.getIdToken();
 
       final response = await http.delete(
-        Uri.parse('https://backend-vgbf.onrender.com/api/posts/$postId'),
-        headers: {'Authorization': 'Bearer $idToken'},
+        Uri.parse('$_backendUrl/$requestId'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $token',
+        },
+        body: jsonEncode({'requester_name': requesterName}),
       );
 
       if (response.statusCode == 200 && mounted) {
-        _fetchUserRoleAndNotices();
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('대타 요청이 성공적으로 삭제되었습니다.')),
+        );
+        _fetchUserRoleAndRequests();
       } else {
-        print('삭제 실패: ${response.body}');
+        final message = jsonDecode(utf8.decode(response.bodyBytes))['message'] ?? '삭제에 실패했습니다.';
+         ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('삭제 실패: $message')),
+        );
       }
     } catch (e) {
-      print('삭제 중 오류 발생: $e');
+      debugPrint('삭제 중 오류: $e');
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('삭제 중 네트워크 오류 발생')),
+      );
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: _isLoading
-          ? Center(child: CircularProgressIndicator())
-          : ListView.builder(
-        itemCount: notices.length,
-        itemBuilder: (context, index) {
-          final notice = notices[index];
-          final isAuthor = userUid != null && userUid == notice.authorUid;
-          final canEdit = userRole == '사장님' || isAuthor;
+    final bool isBoss = userRole == '사장님';
 
-          final koreaDate = DateFormat('yyyy-MM-dd').format(DateTime.parse(notice.createdAt).toLocal());
-
-          return Container(
-            margin: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            height: 160,
-            child: Card(
-              elevation: 2,
-              child: Padding(
-                padding: const EdgeInsets.all(12.0),
+    final body = _isLoading
+        ? const Center(child: CircularProgressIndicator())
+        : requests.isEmpty
+            ? Center(
                 child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.start, // 🔔 아이콘 정렬 통일
-                      children: [
-                        Padding(
-                          padding: EdgeInsets.only(top: 7), // 🔔 아이콘 살짝 내림
-                          child: Icon(Icons.notifications_none, color: Colors.grey[700], size: 28),
-                        ),
-                        SizedBox(width: 8),
-                        Expanded(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              GestureDetector(
-                                onTap: () {
-                                  Navigator.push(
-                                    context,
-                                    MaterialPageRoute(
-                                      builder: (context) => DetailSubPage(notice: notice),
-                                    ),
-                                  ).then((_) {
-                                    if (mounted) _fetchUserRoleAndNotices();
-                                  });
-                                },
-                                child: Text(
-                                  notice.title,
-                                  style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
-                                ),
-                              ),
-                              SizedBox(height: 4),
-                              Text(koreaDate, style: TextStyle(color: Colors.grey, fontSize: 12)),
-                            ],
-                          ),
-                        ),
-                        if (canEdit)
-                          PopupMenuButton<String>(
-                            onSelected: (value) async {
-                              if (value == 'edit') {
-                                final edited = await Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (context) => CreateSubPage(groupId: widget.groupId, notice: notice),
-                                  ),
-                                );
-                                if (edited == true && mounted) _fetchUserRoleAndNotices();
-                              } else if (value == 'delete') {
-                                await _deleteNotice(notice.id);
-                              }
-                            },
-                            itemBuilder: (context) => [
-                              PopupMenuItem(value: 'edit', child: Text('수정하기')),
-                              PopupMenuItem(value: 'delete', child: Text('삭제하기')),
-                            ],
-                            icon: Icon(Icons.more_vert),
-                          ),
-                      ],
+                    Icon(Icons.upcoming, size: 60, color: Colors.grey[400]),
+                    const SizedBox(height: 16),
+                    Text(
+                      isBoss ? '아직 처리할 요청이 없어요.' : '현재 대타를 구하는 요청이 없어요.',
+                      style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold)
                     ),
-                    SizedBox(height: 8),
-                    GestureDetector(
-                      onTap: () {
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(builder: (context) => DetailSubPage(notice: notice)),
-                        ).then((_) {
-                          if (mounted) _fetchUserRoleAndNotices();
-                        });
-                      },
-                      child: Text(
-                        notice.content,
-                        maxLines: 3,
-                        overflow: TextOverflow.ellipsis,
-                      ),
+                    const SizedBox(height: 4),
+                    Text(
+                      isBoss ? '모든 요청이 처리되었거나 새 요청을 기다리고 있습니다.' : '필요한 경우 새 대타 요청을 등록해보세요!',
+                      style: const TextStyle(color: Colors.grey)
                     ),
                   ],
                 ),
-              ),
-            ),
-          );
-        },
-      ),
-      floatingActionButton:
-          FloatingActionButton.extended(
-        backgroundColor: Color(0xFF006FFD),
-        onPressed: () async {
+              )
+            : RefreshIndicator(
+                onRefresh: _fetchUserRoleAndRequests,
+                child: ListView.builder(
+                  padding: const EdgeInsets.all(16),
+                  itemCount: requests.length,
+                  itemBuilder: (context, index) {
+                    final request = requests[index];
+
+                    final bool isAuthorByName = userName != null && userName == request.requesterName;
+                    final bool canDelete = isBoss || (isAuthorByName && request.status == 'PENDING');
+
+                    final String formattedShiftTime =
+                        request.shiftDate.isNotEmpty && request.startTime.isNotEmpty && request.endTime.isNotEmpty
+                        ? DateFormat('MM월 dd일 (E) HH:mm').format(DateTime.parse('${request.shiftDate} ${request.startTime}')) +
+                          ' ~ ' +
+                          DateFormat('HH:mm').format(DateTime.parse('${request.shiftDate} ${request.endTime}'))
+                        : '시간 정보 없음';
+
+                    final String authorDisplay = isAuthorByName
+                        ? '나 (${request.requesterName})'
+                        : request.requesterName;
+
+                    final String firstChar = authorDisplay.isNotEmpty ? authorDisplay[0] : '';
+                    final Color avatarColor = Colors.primaries[firstChar.hashCode % Colors.primaries.length];
+
+                    return GestureDetector(
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                              builder: (context) => DetailSubPage(
+                                  requestId: request.id,
+                                  userRole: userRole!,
+                                ),
+                          ),
+                        ).then((_) {
+                          if (mounted) _fetchUserRoleAndRequests();
+                        });
+                      },
+                      child: Container(
+                        margin: const EdgeInsets.only(bottom: 12),
+                        decoration: BoxDecoration(
+                          color: Colors.white,
+                          borderRadius: BorderRadius.circular(12),
+                          border: Border.all(color: Colors.grey[200]!),
+                          boxShadow: [
+                            BoxShadow(
+                              color: Colors.black.withOpacity(0.05),
+                              spreadRadius: 0,
+                              blurRadius: 4,
+                              offset: const Offset(0, 2),
+                            ),
+                          ],
+                        ),
+                        child: Padding(
+                          padding: const EdgeInsets.all(16.0),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Row(
+                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                children: [
+                                  Row(
+                                    children: [
+                                      CircleAvatar(
+                                        radius: 18,
+                                        backgroundColor: avatarColor.withOpacity(0.15),
+                                        child: Text(
+                                          firstChar,
+                                          style: TextStyle(
+                                            color: avatarColor,
+                                            fontWeight: FontWeight.bold,
+                                            fontSize: 16
+                                          ),
+                                        ),
+                                      ),
+                                      const SizedBox(width: 12),
+                                      Text(
+                                        authorDisplay,
+                                        style: const TextStyle(fontWeight: FontWeight.w600, fontSize: 16),
+                                      ),
+                                    ],
+                                  ),
+                                  Row(
+                                    children: [
+                                      Container(
+                                        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                                        decoration: BoxDecoration(
+                                          color: _getStatusBackgroundColor(request.status),
+                                          borderRadius: BorderRadius.circular(20),
+                                        ),
+                                        child: Text(
+                                          _translateStatus(request.status),
+                                          style: TextStyle(
+                                            fontSize: 12,
+                                            fontWeight: FontWeight.bold,
+                                            color: _getStatusColor(request.status),
+                                          ),
+                                        ),
+                                      ),
+                                      if (canDelete)
+                                        PopupMenuButton<String>(
+                                          onSelected: (value) async {
+                                            if (value == 'delete') {
+                                              if (userName != null) {
+                                                await _deleteRequest(request.id, userName!);
+                                              }
+                                            }
+                                          },
+                                          itemBuilder: (context) => [
+                                            const PopupMenuItem(value: 'delete', child: Text('삭제하기')),
+                                          ],
+                                          icon: const Icon(Icons.more_vert),
+                                          padding: EdgeInsets.zero,
+                                        ),
+                                    ],
+                                  ),
+                                ],
+                              ),
+                              const SizedBox(height: 12),
+                              Padding(
+                                padding: const EdgeInsets.only(left: 10),
+                                child: Text(
+                                  request.reason,
+                                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.w500, color: Colors.grey[800]),
+                                  maxLines: 2,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
+                              const SizedBox(height: 8),
+                              Padding(
+                                padding: const EdgeInsets.only(left: 10),
+                                child: Row(
+                                  children: [
+                                    Icon(Icons.access_time, size: 14, color: Colors.grey[500]),
+                                    const SizedBox(width: 4),
+                                    Text(
+                                      formattedShiftTime,
+                                      style: TextStyle(fontSize: 12, color: Colors.grey[600]),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              );
+
+    final fab = FloatingActionButton.extended(
+      backgroundColor: isBoss ? const Color(0xFF10B981) : const Color(0xFF006FFD),
+      onPressed: () async {
+        if (isBoss) {
+          // 사장님: 승인 목록 페이지로 이동
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (context) => ApprovalRequestsPage(groupId: widget.groupId)),
+          ).then((_) {
+            if (mounted) _fetchUserRoleAndRequests();
+          });
+        } else {
+          // 알바생: 대타 요청 생성 페이지로 이동
           final created = await Navigator.push(
             context,
             MaterialPageRoute(builder: (context) => CreateSubPage(groupId: widget.groupId)),
           );
-          if (created == true && mounted) _fetchUserRoleAndNotices();
-        },
-        label: Text('CREATE', style: TextStyle(color: Colors.white)),
-        icon: Icon(Icons.add, color: Colors.white),
-      )
+          if (created == true && mounted) _fetchUserRoleAndRequests();
+        }
+      },
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(30)),
+      label: Text(
+        isBoss ? '대타 요청 승인' : '대타 요청하기',
+        style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold, fontSize: 16)
+      ),
+      icon: Icon(isBoss ? Icons.check_circle_outline : Icons.add, color: Colors.white),
+    );
 
+    return Scaffold(
+      body: body,
+      floatingActionButton: fab,
+      floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
     );
   }
 }

--- a/albamate_sample/lib/screen/groupPage/notice/substitute_request.dart
+++ b/albamate_sample/lib/screen/groupPage/notice/substitute_request.dart
@@ -1,0 +1,45 @@
+// 대타 요청 서버 응답을 위한 모델
+
+class SubstituteRequest {
+  final String id;
+  final String groupId;
+  final String requesterName; // 요청자 이름 (requester_name)
+  final String? substituteName; // 대타 이름 (substitute_name, 수락 시)
+  final String shiftDate; // 근무 날짜 (shift_date)
+  final String startTime; // 시작 시간 (start_time)
+  final String endTime; // 종료 시간 (end_time)
+  final String reason; // 요청 사유 (reason)
+  final String status; // 요청 상태 (status: PENDING, IN_REVIEW, APPROVED, REJECTED)
+  final String createdAt;
+  final String? approvedAt; // 승인 시점
+
+  SubstituteRequest({
+    required this.id,
+    required this.groupId,
+    required this.requesterName,
+    this.substituteName,
+    required this.shiftDate,
+    required this.startTime,
+    required this.endTime,
+    required this.reason,
+    required this.status,
+    required this.createdAt,
+    this.approvedAt,
+  });
+
+  factory SubstituteRequest.fromJson(Map<String, dynamic> json) {
+    return SubstituteRequest(
+      id: json['id'] as String,
+      groupId: json['group_id'] as String,
+      requesterName: json['requester_name'] as String,
+      substituteName: json['substitute_name'] as String?,
+      shiftDate: json['shift_date'] as String,
+      startTime: json['start_time'] as String,
+      endTime: json['end_time'] as String,
+      reason: json['reason'] as String,
+      status: json['status'] as String,
+      createdAt: json['created_at'] as String,
+      approvedAt: json['approved_at'] as String?,
+    );
+  }
+}

--- a/albamate_sample/lib/screen/groupPage/schedule/schedule_request_nav.dart
+++ b/albamate_sample/lib/screen/groupPage/schedule/schedule_request_nav.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:albamate_sample/screen/groupPage/schedule/create_schedule.dart';
 import 'package:albamate_sample/screen/groupPage/schedule/schedule_card.dart';
 import 'package:albamate_sample/screen/groupPage/schedule/worker_scheduleView.dart'; // ✅ 추가
-import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../../../config/api.dart';

--- a/albamate_sample/lib/screen/groupPage/schedule/schedule_request_nav.dart
+++ b/albamate_sample/lib/screen/groupPage/schedule/schedule_request_nav.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:albamate_sample/screen/groupPage/schedule/create_schedule.dart';
 import 'package:albamate_sample/screen/groupPage/schedule/schedule_card.dart';
 import 'package:albamate_sample/screen/groupPage/schedule/worker_scheduleView.dart'; // ✅ 추가
+import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../../../config/api.dart';

--- a/albamate_sample/pubspec.yaml
+++ b/albamate_sample/pubspec.yaml
@@ -30,6 +30,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  # ✅ 이 부분을 아래와 같이 수정하세요:
+  flutter_localizations:
+    sdk: flutter
   image_picker: ^1.0.7
   http: ^1.3.0
 
@@ -40,7 +43,7 @@ dependencies:
   firebase_auth: ^5.5.1
   cloud_firestore: ^5.6.5
   syncfusion_flutter_calendar: ^29.1.40
-  intl: ^0.20.2
+  intl: ^0.19.0
   msh_checkbox: ^2.0.1
   flutter_slidable: ^3.0.0
   supabase_flutter: ^2.9.0


### PR DESCRIPTION
1. 스케줄 유효성 핵심 검증 로직 추가

- 대타 요청 시, 요청자가 해당 날짜에 사장님에게 승인된(APPROVED) 확정 스케줄이 실제로 존재하는지 확인합니다.

- 요청된 대타 시간(shift_date, start_time, end_time)이 요청자의 확정된 근무 시간 범위 내에 완전히 포함되어야만 게시글 등록을 허용합니다. (확정되지 않은 근무를 요청하거나, 확정 근무 시간을 벗어난 요청을 방지)

2. 대타 요청 등록 기능 완성:

POST /api/substitute/requests 엔드포인트를 통해 유효성 검증을 통과한 요청을 DB의 substitute_requests 테이블에 status: PENDING 상태로 저장합니다.

3. 역할 기반 조회 로직 구현:

사장님과 알바생의 역할에 따라 status 필터링을 달리 적용하여 조회할 수 있도록 로직을 분리했습니다.

알바생 조회: PENDING (대타 찾는 중) 상태의 글만 노출됩니다. 자신의 글만 삭제 가능

사장님 조회: 모든 상태의 글을 조회, 삭제 가능

4. 사장님이 승인(APPROVED) 시 실제 스케줄 변경 